### PR TITLE
Rename icecream::_() to icecream::f_().

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,14 +210,14 @@ will print:
 
 
 The output formatting configuration is done wrapping a format string and the values with
-the function `icecream::_()`, like in:
+the function `icecream::f_()`, like in:
 
 ```C++
-using icecream::_;
+using icecream::f_;
 auto a = int{42};
 
-IC(_("X", a));
-IC(_("0v#6x", 20, 30), 40, _("*>6", a));
+IC(f_("X", a));
+IC(f_("0v#6x", 20, 30), 40, f_("*>6", a));
 ```
 
 that will print:
@@ -227,7 +227,7 @@ that will print:
 
 
 If the same formatting string should be applied to all the values on an `IC` macro call,
-you can use the `IC_` macro as a shortcut. The code `IC(icecream::_("#x", a, b))` can be
+you can use the `IC_` macro as a shortcut. The code `IC(icecream::f_("#x", a, b))` can be
 rewritten as `IC_("#x", a, b)`.
 
 

--- a/icecream.hpp
+++ b/icecream.hpp
@@ -81,11 +81,11 @@
 #if defined(ICECREAM_LONG_NAME)
     #define ICECREAM(...) ::icecream::detail::Dispatcher{__FILE__, __LINE__, ICECREAM_FUNCTION, #__VA_ARGS__}.ret(__VA_ARGS__)
     #define ICECREAM0() ::icecream::detail::Dispatcher{__FILE__, __LINE__, ICECREAM_FUNCTION, ""}.ret()
-    #define ICECREAM_(F,...) ICECREAM(::icecream::_(F, __VA_ARGS__))
+    #define ICECREAM_(S,...) ICECREAM(::icecream::f_(S, __VA_ARGS__))
 #else
     #define IC(...) ::icecream::detail::Dispatcher{__FILE__, __LINE__, ICECREAM_FUNCTION, #__VA_ARGS__}.ret(__VA_ARGS__)
     #define IC0() ::icecream::detail::Dispatcher{__FILE__, __LINE__, ICECREAM_FUNCTION, ""}.ret()
-    #define IC_(F,...) IC(::icecream::_(F, __VA_ARGS__))
+    #define IC_(S,...) IC(::icecream::f_(S, __VA_ARGS__))
 #endif
 
 
@@ -486,7 +486,7 @@ namespace icecream{ namespace detail
                 conjunction<
                     negation<is_instantiation<FormatterPack, typename std::decay<Ts>::type>>...
                 >::value,
-                "It is not possible to nest FormmaterPack's as in IC_(\"#\", 7, _(\"#x\", 42))."
+                "It is not possible to nest FormmaterPack's as in IC_(\"#\", 7, f_(\"#x\", 42))."
             );
         }
 
@@ -2273,7 +2273,7 @@ namespace icecream{ namespace detail
             return std::string{b_it, e_it+1};
         }
 
-        // Receive a string with a `icecream::_("0v#4x", a, b, c)` call, and returns a vector with all the variable names.
+        // Receive a string with a `icecream::f_("0v#4x", a, b, c)` call, and returns a vector with all the variable names.
         // In this example, a vector with ["a", "b", "c"].
         static
         auto split_variable_names(std::string const& var_name) -> std::vector<std::string>
@@ -2487,7 +2487,7 @@ namespace icecream
     }
 
     template<typename... Ts>
-    auto _(std::string const& fmt, Ts&&... vs) -> detail::FormatterPack<decltype(std::forward<Ts>(vs))...>
+    auto f_(std::string const& fmt, Ts&&... vs) -> detail::FormatterPack<decltype(std::forward<Ts>(vs))...>
     {
         return detail::FormatterPack<decltype(std::forward<Ts>(vs))...>{fmt, std::forward<Ts>(vs)...};
     }

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -143,7 +143,7 @@ TEST_CASE("return")
     auto sstr = std::stringstream {};
     icecream::ic.stream().rdbuf(sstr.rdbuf());
 
-    using icecream::_;
+    using icecream::f_;
 
     {
         // !v0 is a dangling reference!
@@ -200,9 +200,9 @@ TEST_CASE("return")
         auto a = int{10};
         auto const b = int{20};
 
-        auto&& v0 = IC(_("0v#4x", a, b), 49);
+        auto&& v0 = IC(f_("0v#4x", a, b), 49);
         REQUIRE(std::is_same<decltype(v0), std::tuple<int&, int const&, int&&>&&>::value);
-        REQUIRE(IC(_("0v#4x", a, b), 49) == std::make_tuple(10, 20, 49));
+        REQUIRE(IC(f_("0v#4x", a, b), 49) == std::make_tuple(10, 20, 49));
     }
 
     {
@@ -905,11 +905,11 @@ TEST_CASE("formatting")
     auto sstr = std::stringstream {};
     icecream::ic.stream().rdbuf(sstr.rdbuf());
 
-    using icecream::_;
+    using icecream::f_;
 
     {
         auto v0 = int{42};
-        IC(_("#x", v0), 7);
+        IC(f_("#x", v0), 7);
         REQUIRE(sstr.str() == "ic| v0: 0x2a, 7: 7\n");
         sstr.str("");
     }
@@ -923,14 +923,14 @@ TEST_CASE("formatting")
 
     {
         auto v0 = int{42};
-        IC( ((_("#", (v0) )   )), 7);
+        IC( ((f_("#", (v0) )   )), 7);
         REQUIRE(sstr.str() == "ic| v0: 42, 7: 7\n");
         sstr.str("");
     }
 
     {
         auto v0 = float{12.3456789};
-        IC((_("#A", v0)));
+        IC((f_("#A", v0)));
         REQUIRE(
             ((sstr.str() == "ic| v0: 0X1.8B0FCEP+3\n") ||
              (sstr.str() == "ic| v0: 0X1.8B0FCE0000000P+3\n")) // Visualstudio 2019 output


### PR DESCRIPTION
That is done to avoid a name collision when the text translation _ function is implemented
as a macro on some libraries.
Closes #18 