### PR TITLE
Fix an out of range memory access on string literal printing.

### DIFF
--- a/icecream.hpp
+++ b/icecream.hpp
@@ -2579,7 +2579,14 @@ namespace icecream{ namespace detail
                     // Don't split anything inside a string
 
                     ++left_cut;
-                    while (!(*left_cut == '"' && (left_cut+1) != left_end && *(left_cut+1) != '\\')) ++left_cut;
+                    while (
+                        !(  // Will iterate with left_cut until the stop condition:
+                            (left_cut+1) == left_end                        // The next position is the end iterator
+                            || (*left_cut == '"' && *(left_cut+1) != '\\')  // The current char the closing quotation
+                        )
+                    ) {
+                        ++left_cut;
+                    }
                     ++left_cut;
                 }
                 else if (*left_cut == '\'' && *(left_cut+1) != '\\')
@@ -2587,7 +2594,14 @@ namespace icecream{ namespace detail
                     // Don't split a ',' (a comma between single quotation marks)
 
                     ++left_cut;
-                    while (!(*left_cut == '\'' && (left_cut+1) != left_end && *(left_cut+1) != '\\')) ++left_cut;
+                    while (
+                        !(  // Will iterate with left_cut until the stop condition:
+                            (left_cut+1) == left_end                         // The next position is the end iterator
+                            || (*left_cut == '\'' && *(left_cut+1) != '\\')  // The current char is the closing quotation
+                        )
+                    ) {
+                        ++left_cut;
+                    }
                     ++left_cut;
                 }
             }

--- a/tests/test_c++11.cpp
+++ b/tests/test_c++11.cpp
@@ -299,6 +299,22 @@ TEST_CASE("base")
         IC(mc);
         REQUIRE(str == "ic| mc: <MyClass 20>\n");
     }
+
+    {
+        auto str = std::string{};
+        icecream::ic.output(str);
+
+        IC("Hi");
+        REQUIRE(str == "ic| \"Hi\": ['H', 'i', '\\0']\n");
+    }
+
+    {
+        auto str = std::string{};
+        icecream::ic.output(str);
+
+        IC('a');
+        REQUIRE(str == "ic| 'a': 'a'\n");
+    }
 }
 
 


### PR DESCRIPTION
The invalid access would happen when printing a first argument literal string or literal char.

Fix #48