### PR TITLE
Switch receiving printing args from const ref to perfect forwarding.

### DIFF
--- a/tests/common.hpp
+++ b/tests/common.hpp
@@ -42,5 +42,21 @@ public:
 };
 
 
+class MutableStream
+{
+public:
+    explicit MutableStream(int i_)
+        : i {i_}
+    {}
+
+    int i;
+
+    friend auto operator<<(std::ostream& os, MutableStream& self) -> std::ostream&
+    {
+        os << "<MutableStream " << self.i << ">";
+        return os;
+    }
+};
+
 
 #endif // TESTS_COMMON_HPP_INCLUDED

--- a/tests/test_c++11.cpp
+++ b/tests/test_c++11.cpp
@@ -362,6 +362,15 @@ TEST_CASE("base")
         #undef V0
     }
 
+    {
+        IC_CONFIG_SCOPE();
+        auto str = std::string{};
+        IC_CONFIG.output(str);
+
+        auto ms = MutableStream{7};
+        IC(ms);
+        REQUIRE(str == "ic| ms: <MutableStream 7>\n");
+    }
 }
 
 


### PR DESCRIPTION
With this we can print values that must be mutable. Like a type with a non const reference on ostream << overload.