### PR TITLE
Fix careless inclusion of range-v3 headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,11 +243,12 @@ each iteration in the `for` loop one line will be printed, until we have the out
     ic| range_view_61:53[2]: (2, 'c')
 
 > [!NOTE]
-> IceCream-Cpp will try to detect if the Range-v3 library is installed, and if so, the
-> support to it will be automatically enabled. When using C++11 and C++14 however, there
-> is a chance of having Range-v3 in the system, but IceCream not finding it. To make sure
-> that the support to Range-v3 is enabled, just define the macro `ICECREAM_RANGE_V3`
-> before including the `icecream.hpp` header
+> The Icecream-cpp will search the current scope trying to detect any "#included" range-v3
+> header. If any is dectected, the support to range-v3 will be automatically enabled.
+> While convenient, that requires that the Icecream-cpp header be included at a line below
+> some range-v3 header. To make sure that the support to range-v3 is enabled regardless of
+> that header detection, you can define a macro `ICECREAM_RANGE_V3` before including the
+> `icecream.hpp` header
 
 The `IC_V` function has two optional parameters, `IC_V(name, projection)`.
 

--- a/icecream.hpp
+++ b/icecream.hpp
@@ -89,11 +89,21 @@
     #endif
 #endif
 
-#if defined(ICECREAM_RANGE_V3)                                                  \
-    || (defined(__has_include) && __has_include(<range/v3/view/transform.hpp>)) \
-    || defined(RANGE_V3_VERSION)
+// ICECREAM_RANGE_V3 is the macro which the user may define to enable range-v3 support
+// regardless of any other condition.
+//
+// The "defined()" test for RANGES_V3_DETAIL_CONFIG_HPP macro is an attempt to check if
+// any range-v3 header was "#included" before the including of this icecream-cpp header.
+// If so, the range-v3 support will be enabled.
+#if defined(ICECREAM_RANGE_V3) || defined(RANGES_V3_DETAIL_CONFIG_HPP)
+    // The RANGES_V3_DETAIL_CONFIG_HPP is the include guard of the header
+    // <range/v3/detail/config.hpp>. This header is present in all range-v3 releases, and
+    // is direct or indirectly included by all other range-v3 headers, excepting a few
+    // ones like <range/v3/version.hpp>. Because of that, checking by the definition of
+    // RANGES_V3_DETAIL_CONFIG_HPP is a good way to determine if any range-v3 header was
+    // previouly included .
 
-    #define ICECREAM_RANGE_V3
+    #define ICECREAM_RANGE_V3_ENABLED
     #include <range/v3/version.hpp>
     #include <range/v3/view/transform.hpp>
 
@@ -4776,7 +4786,7 @@ namespace detail {
   #endif
 
 
-  #if defined(ICECREAM_RANGE_V3)
+  #if defined(ICECREAM_RANGE_V3_ENABLED)
     // View | IC_V
     template <typename T, typename Proj>
     auto operator|(T&& t, RangeViewArgs<Proj> view_args)

--- a/tests/test_range_v3.cpp
+++ b/tests/test_range_v3.cpp
@@ -1,9 +1,9 @@
-#include "icecream.hpp"
-
 #include <range/v3/view.hpp>
 #include <range/v3/version.hpp>
 #include <vector>
 #include <forward_list>
+
+#include "icecream.hpp"
 
 #define CATCH_CONFIG_MAIN
 #include <catch2/catch.hpp>


### PR DESCRIPTION
Before this change the range-v3 headers were being included whenever they were found in the system, even if they weren't used in a translation unit.

Now the required range-v3 headers will only be included if another range-v3 header is included before or if explicitly requested.