### PR TITLE
Change std::optional formatting syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -1258,7 +1258,7 @@ IC_F("n|#x||.3e", v0);
 will print:
 
 ```
-ic| ic| v0: 0x14, "foo", 1.230e-02
+ic| v0: 0x14, "foo", 1.230e-02
 ```
 
 ###### casing
@@ -1301,6 +1301,24 @@ ic| v0: 10, v1: nullopt
 
 This strategy has a lower precedence than the "baseline strategies". So if the printing
 type is supported by any one of them it will used instead.
+
+##### Optional types format string
+
+```
+optional_spec  ::= [":"element_fmt]
+element_fmt ::= <format specification of the element type>
+```
+
+```C++
+auto v0 = std::optional<int>{50};
+IC_F(":#x", v0);
+```
+
+will print:
+
+```
+ic| v0: 0x32
+```
 
 #### Variant types
 

--- a/icecream.hpp
+++ b/icecream.hpp
@@ -3611,8 +3611,29 @@ namespace detail {
         PrintingNode
     >::type
     {
+        auto container_fmt = StringView{};
+        auto element_fmt = StringView{};
+
+        auto const cut_idx = fmt.find(":");
+        if (cut_idx != StringView::npos)
+        {
+            auto const fmt_parts = split(fmt, std::vector<size_t>{cut_idx});
+            container_fmt = fmt_parts[0];
+            element_fmt = fmt_parts[1];
+        }
+        else
+        {
+            container_fmt = fmt;
+        }
+
+        // std::optional hasn't any container formatting string
+        if (!container_fmt.empty())
+        {
+            return PrintingNode("*Error* on formatting string");
+        }
+
         return value.has_value() ?
-            make_printing_branch(*value, fmt, config) : PrintingNode("nullopt");
+            make_printing_branch(*value, element_fmt, config) : PrintingNode("nullopt");
     }
   #endif
 

--- a/tests/test_c++17.cpp
+++ b/tests/test_c++17.cpp
@@ -57,6 +57,16 @@ TEST_CASE("std_optional")
         IC(s2);
         REQUIRE(str == "ic| s2: ||opt MyClass|| <MyClass 1>\n");
     }
+
+    {
+        IC_CONFIG_SCOPE();
+        auto str = std::string{};
+        IC_CONFIG.output(str);
+
+        auto s0 = std::optional<int>{50};
+        IC_F(":#x", s0);
+        REQUIRE(str == "ic| s0: 0x32\n");
+    }
 }
 
 


### PR DESCRIPTION
To follow the syntax of containers, now the inner type formatting string must be after a ":" character.