### PR TITLE
Fix a dangling reference when using prvalue args in IC_A and IC_FA

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ and forward.
 * [Usage](#usage)
   * [Direct printing](#direct-printing)
   * [Range views pipeline](#range-views-pipeline)
-  * [Return value and IceCream apply macro](#return-value-and-icecream-apply-macro)
+  * [Return value and Icecream apply macro](#return-value-and-icecream-apply-macro)
   * [Output formatting](#output-formatting)
   * [C strings](#c-strings)
   * [Character Encoding](#character-encoding)
@@ -336,52 +336,47 @@ when iterated over will print:
 > have any effect on that.
 
 
-### Return value and IceCream apply macro
+### Return value and Icecream apply macro
 
-The [`IC`](#direct-printing) function (and [`IC_F`](#output-formatting)) will return a
-tuple with all its input arguments. Except when called with exactly one argument, when
+The [`IC`](#direct-printing) function (and [`IC_F`](#output-formatting)) won't return any
+value in its general case. Exception to that if called with exactly one argument, when
 then it will return the argument itself.
 
-This is done this way so that you can use `IC` to inspect a function argument at calling
-point, with no further code change. In the code:
+This is done this way so we can use `IC` to inspect a function argument at calling point,
+without further code change. In the code:
 
 ```C++
 my_function(IC(MyClass{}));
 ```
-the `MyClass` object will be forwarded to `my_function` exactly the same as if the
-`IC` function wasn't there. The `my_function` will continue receiving a rvalue reference to a
-`MyClass` object.
+the `MyClass` object will be forwarded to `my_function` as if the `IC` function wasn't
+there. The `my_function` will continue receiving a rvalue reference to a `MyClass` object.
 
-This approach however is not so practical when the function has multiple arguments. On the code:
+This approach however is not so practical when the function has multiple arguments. In the code:
 ```C++
-my_function(IC(a), IC(b), IC(c), IC(d));
+another_function(IC(a), IC(b), IC(c), IC(d));
 ```
 besides writing four times the `IC` function, the printed output will be split in four
-distinct lines. Something like:
+lines. Something like:
 
     ic| a: 1
     ic| b: 2
     ic| c: 3
     ic| d: 4
 
-Unfortunately, just wrapping all the four arguments in a single `IC` call will not work
-too. The returned value will be one `std:::tuple` with `(a, b, c, d)` and `my_function`
-expects four arguments.
-
 To work around that, there is the `IC_A` function. `IC_A` behaves exactly like the `IC`
 function, but receives a [callable](https://en.cppreference.com/w/cpp/named_req/Callable)
-as its first argument, and will call it using all the next arguments, printing all of them
-before that. That previous example code could be rewritten as:
+as its first argument, and will call it using the remaining arguments, printing all of
+them before that. That previous example code could be rewritten as:
 
 ```C++
-IC_A(my_function, a, b, c, d);
+IC_A(another_function, a, b, c, d);
 ```
 
 and this time it will print:
 
     ic| a: 1, b: 2, c: 3, d: 4
 
-The `IC_A` function will return the same value as returned by the callable. The code:
+The `IC_A` function will return the same value returned by the callable. The code:
 
 ```C++
 auto mc = std::make_unique<MyClass>();

--- a/tests/test_c++11.cpp
+++ b/tests/test_c++11.cpp
@@ -176,7 +176,7 @@ TEST_CASE("apply")
         auto mc = MyClass{3};
         auto r = IC_A(mc.multiply, 10);
         REQUIRE(str == "ic| 10: 10\n");
-        REQUIRE(r == 30);
+        REQUIRE(r == mc.multiply(10));
     }
 
     {
@@ -187,7 +187,7 @@ TEST_CASE("apply")
         auto mc = MyClass{3};
         auto r = IC_A(mc.add, MyClass{7});
         REQUIRE(str == "ic| MyClass{7}: <MyClass 7>\n");
-        REQUIRE(r == 10);
+        REQUIRE(r == mc.add(MyClass{7}));
     }
 
     {
@@ -402,7 +402,7 @@ TEST_CASE("return")
 
     {
         auto irval = [](int&&){return 10;};
-        REQUIRE(IC_A(irval, 7) == 10);
+        REQUIRE(IC_A(irval, 7) == irval(7));
     }
 
     {
@@ -427,41 +427,6 @@ TEST_CASE("return")
     {
         REQUIRE(std::is_same<decltype(IC_F("#o", 7)), int&&>::value);
         REQUIRE(IC_F("#o", 7) == 7);
-    }
-
-    {
-        auto const a = int{20};
-
-        REQUIRE(
-            std::is_same<
-                decltype(IC(7, 3.14, a)),
-                std::tuple<int&&, double&&, int const&>
-            >::value
-        );
-
-        // !v0 has a dangling reference to 7 and 3.14!
-        auto v0 = IC(7, 3.14, a);
-        REQUIRE(&std::get<2>(std::move(v0)) == &a);
-        REQUIRE((IC(7, 3.14, a) == std::make_tuple(7, 3.14, 20)));
-    }
-
-    {
-        auto a = int{30};
-
-        REQUIRE(
-            std::is_same<
-                decltype(IC_F("#", 7, a, 3.14)),
-                std::tuple<int&&, int&, double&&>
-            >::value
-        );
-
-        auto v0 = IC_F("#", 7, a, 3.14);
-        REQUIRE(&std::get<1>(std::move(v0)) == &a);
-        REQUIRE(IC_F("#", 7, a, 3.14) == std::make_tuple(7, 30, 3.14));
-    }
-
-    {
-        REQUIRE(std::is_same<decltype(IC()), std::tuple<>>::value);
     }
 }
 


### PR DESCRIPTION
Before this patch a prvalue would be stored within tuple as a rvalue reference, and wouldn't be alive when applied to the callable. This change that to store any rvalue as a value within the tuple, and that value will be then moved when being applied to the callable.