### PR TITLE
Update windows CI runner image

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -80,18 +80,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2022, windows-2019]
+        os: [windows-2025]
         cpp: [14, 17, 20, 23]
-        exclude:
-          - os: windows-2019
-            cpp: 20
-          - os: windows-2019
-            cpp: 23
         include:
-          - os: windows-2022
-            name: vs2022
-          - os: windows-2019
-            name: vs2019
+          - os: windows-2025
+            name: MSVC 17.14
           - range_v3: ON
           - range_v3: OFF
             cpp: 14

--- a/tests/test_strings_c++11.cpp
+++ b/tests/test_strings_c++11.cpp
@@ -1,10 +1,10 @@
-#include "icecream.hpp"
-
-#include <string>
-
 #if defined(_MSC_VER)
   #pragma warning(disable: 4571 4868 5045)
 #endif
+
+#include "icecream.hpp"
+
+#include <string>
 
 #define CATCH_CONFIG_MAIN
 #include <catch2/catch.hpp>

--- a/tests/test_strings_c++17.cpp
+++ b/tests/test_strings_c++17.cpp
@@ -1,11 +1,11 @@
+#if defined(_MSC_VER)
+  #pragma warning(disable: 4571 4868 5045)
+#endif
+
 #include "icecream.hpp"
 
 #include <string>
 #include <string_view>
-
-#if defined(_MSC_VER)
-  #pragma warning(disable: 4571 4868 5045)
-#endif
 
 #define CATCH_CONFIG_MAIN
 #include <catch2/catch.hpp>

--- a/tests/test_strings_c++20.cpp
+++ b/tests/test_strings_c++20.cpp
@@ -1,11 +1,11 @@
+#if defined(_MSC_VER)
+  #pragma warning(disable: 4571 4868 5045)
+#endif
+
 #include "icecream.hpp"
 
 #include <string>
 #include <string_view>
-
-#if defined(_MSC_VER)
-  #pragma warning(disable: 4571 4868 5045)
-#endif
 
 #define CATCH_CONFIG_MAIN
 #include <catch2/catch.hpp>


### PR DESCRIPTION
Remove the deprecated windows-2019.

Both available runner windows images (2022 and 2025), have the same MSVC version, so we will run the tests in only one.