### PR TITLE
Hold a std::ostream reference instead of std::streambuf in Output

### DIFF
--- a/tests/test_c++11.cpp
+++ b/tests/test_c++11.cpp
@@ -126,6 +126,18 @@ TEST_CASE("output")
         IC(1, 2);
         REQUIRE(str == "ic| 1: 1, 2: 2\n");
     }
+
+    {
+        IC_CONFIG_SCOPE();
+        auto sstr = std::ostringstream{};
+        auto cout_buff = std::cout.rdbuf();
+        IC_CONFIG.output(std::cout);
+        std::cout.rdbuf(sstr.rdbuf());
+        IC(1, 2);
+        std::cout.rdbuf(cout_buff);
+        IC_CONFIG.output(sstr);
+        REQUIRE(sstr.str() == "ic| 1: 1, 2: 2\n");
+    }
 }
 
 


### PR DESCRIPTION
Before, when setting a std::ostream as the new Output, we would store a reference to its internal std::streambuf instead. This is a semantic bug, because if we change the std::streambuf of that std::ostream for any reason, Icecream will still write to the old one.

Fix #92