### PR TITLE
Added macros that returns formatted value

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ all the functionalities of Icecream-cpp library will be available by the functio
 [`IC`](#direct-printing), [`IC_A`](#return-value-and-icecream-apply-macro), and
 [`IC_V`](#range-views-pipeline); together with its respective counterparts `IC_F`,
 `IC_FA`, and `IC_FV`; that behave the same but accept an [output formatting
-string](#output-formatting) as its first argument.
+string](#output-formatting) as its first argument. `IC_R`and `IC_FR` [returns formatted `std::string`](#return-formatted-string) instead of printing it.
 
 
 ### Direct printing
@@ -485,6 +485,48 @@ used by Icecream-cpp.
 To `IC_FV`, the formatting syntax if the same as the [Range format
 string](#range-format-string).
 
+### Return formatted string
+
+`IC` and `IC_F` returns unchanged values. If you need a formatted value, you can use a `IC_R` (return) or `IC_FR` (format and return). For example, this vector:
+
+
+```c++
+auto v = std::vector<int>{10, 11, 12, 13, 14};
+auto str = IC_R(v);
+```
+
+will be assigned to `str` as:
+```
+ic| v: [10, 11, 12, 13, 14]
+```
+
+You can slice any values from it using [range format](#range-format-string):
+```c++
+auto str = IC_FR("[0:2]", v);
+```
+
+The `str` now contains:
+```
+ic| v: [10, 11, 12]
+```
+
+It can be used to create complex output by mixing IceCream with [formatting libraries](#printing-strategies) like [{fmt}](#fmt-1). 
+
+This code:
+```c++
+IC_CONFIG.prefix("");
+auto v = std::vector<int>{10, 11, 12, 13, 14};
+auto i = 21;
+fmt::print("Pushing {} to the {}", IC_FR("#x", i), IC_R(v))
+```
+
+will print:
+```
+Pushing i: 0x15 to the v: [10, 11, 12, 13, 14]
+```
+
+
+
 
 ### C strings
 
@@ -715,7 +757,10 @@ auto str = std::string{};
 IC_CONFIG.output(str);
 IC(1, 2);
 ```
-Will print the output `"ic| 1: 1, 2: 2\n"` in the `str` string.
+Will print the output `"ic| 1: 1, 2: 2\n"` in the `str` string. `IC_R` and `IC_FR` returns the same string:
+```c++
+auto str = IC_R(1, 2);
+```
 
 > [!WARNING]
 > Icecream-cpp won't take ownership of the `t` argument, so care must be taken by the user
@@ -1521,7 +1566,19 @@ ic| s: {f: 3.14, ii: [1, 2, 3]}
 ```
 
 This strategy has a lowest precedence of all the printing strategies. So if the printing
-type is supported by any one of them it will used instead.
+type is supported by any one of them it will used instead. You can mix this dump with any strategy, e.g. with `fmt::print()`.
+
+The code:
+```c++
+IC_CONFIG.prefix("");
+S s = {3.14, {1,2,3}};    
+fmt::print("Testing class {}", IC_R(s));   
+```
+will print:
+```
+Testing class s: {f: 3.14, ii: [1, 2, 3]}
+```
+
 
 ### Third-party libraries
 

--- a/icecream.hpp
+++ b/icecream.hpp
@@ -300,6 +300,9 @@
     #define IC_V(...) ::icecream::detail::IC_V_(__VA_ARGS__).complete(icecream_private_config_5f803a3bcdb4, __LINE__, __FILE__, ICECREAM_FUNCTION)
     #define IC_FV(...) ::icecream::detail::IC_FV_(__VA_ARGS__).complete(icecream_private_config_5f803a3bcdb4, __LINE__, __FILE__, ICECREAM_FUNCTION)
 
+    #define IC_R(...) ICECREAM_DISPATCH(false, "", #__VA_ARGS__).string_run(__VA_ARGS__)
+    #define IC_FR(fmt, ...) ICECREAM_DISPATCH(false, fmt, #__VA_ARGS__).string_run(__VA_ARGS__)
+
     #if defined(__GNUC__)
         // Disable global and outer scope name shadowing warnings
         //
@@ -2571,7 +2574,7 @@ namespace icecream{ namespace detail
             return *this;
         }
 
-    protected:
+    public:
 
         Config() = default;
 
@@ -5422,7 +5425,7 @@ namespace detail {
         template <typename T>
         auto unary_run(T&& arg) -> T&&
         {
-            this->dispatch(make_int_sequence<1>(), arg);
+            this->dispatch(config_, make_int_sequence<1>(), arg);
             return std::forward<T>(arg);
         }
 
@@ -5431,7 +5434,7 @@ namespace detail {
         template <typename... Ts>
         auto unary_run(Ts&&... args) -> void
         {
-            this->dispatch(make_int_sequence<sizeof...(Ts)>(), args...);
+            this->dispatch(config_, make_int_sequence<sizeof...(Ts)>(), args...);
         }
 
         // Runs the Dispatcher and returns a tuple with all the arguments.
@@ -5444,13 +5447,24 @@ namespace detail {
         template <typename... Ts>
         auto tuple_run(Ts&&... args) -> std::tuple<custody_t<Ts>...>
         {
-            this->dispatch(make_int_sequence<sizeof...(Ts)>(), args...);
+            this->dispatch(config_, make_int_sequence<sizeof...(Ts)>(), args...);
             return std::tuple<custody_t<Ts>...>(std::forward<Ts>(args)...);
         }
 
+        // Runs the Dispatcher and returns the formatted string.
+        // Can be passed to any ostream or fmt::
+        template <typename... Ts>
+        auto string_run(Ts&&... args) -> std::string
+        {
+            Config_ local_config(&config_);
+            local_config.set_output(buffer);
+            this->dispatch(local_config, make_int_sequence<sizeof...(Ts)>(), std::forward<Ts>(args)...);
+            return buffer.str();
+        }
+
     private:
-        template <size_t... N, typename... Ts>
-        auto dispatch(int_sequence<N...>, Ts&&... args) -> void
+        template <size_t... N, typename... Us>
+        auto dispatch(Config_& config, int_sequence<N...>, Us&&... args) -> void
         {
             // Pick the name of an IC macro's "to be printed" argument. Usually that would
             // just return the argument string itself. However, when using the IC_ macro
@@ -5487,7 +5501,7 @@ namespace detail {
                 arg_names.erase(arg_names.begin());
             }
 
-            if (sizeof...(Ts) == 0 && !this->is_ic_apply_)
+            if (sizeof...(Us) == 0 && !this->is_ic_apply_)
             {
                 // Even if it has no arguments (besides the callable name), an `IC_A`
                 // macro isn't a nullary `IC()` call.
@@ -5496,14 +5510,14 @@ namespace detail {
             else
             {
                 print_args(
-                    config_,
+                    config,
                     file_,
                     line_,
                     function_,
-                    PrintingArgument<formatting_argumet_type<Ts>>{
+                    PrintingArgument<formatting_argumet_type<Us>>{
                         arg_names.at(N),
                         get_fmt(args, this->default_format_),
-                        get_value(std::forward<Ts>(args))
+                        get_value(std::forward<Us>(args))
                     }...
                 );
             }
@@ -5516,6 +5530,7 @@ namespace detail {
         StringView function_;
         StringView default_format_;
         StringView arg_names_;
+        std::ostringstream buffer;
     };
 
     // --------------------------------------------------- Range View

--- a/tests/test_c++23.cpp
+++ b/tests/test_c++23.cpp
@@ -29,6 +29,9 @@ TEST_CASE("STL formatting lib")
 
         IC(v0);
         REQUIRE(str == result);
+
+        str = IC_R(v0);
+        REQUIRE(str == result);
     }
 
     {
@@ -44,6 +47,9 @@ TEST_CASE("STL formatting lib")
             "    v0: (10, 20, 30, 40, 50, 60)\n";
 
         IC(v0);
+        REQUIRE(str == result);
+
+        str = IC_R(v0);
         REQUIRE(str == result);
     }
   #endif

--- a/tests/test_clang.cpp
+++ b/tests/test_clang.cpp
@@ -43,7 +43,10 @@ TEST_CASE("dump_string")
       #endif
 
         IC(v0);
-        REQUIRE_THAT(str, Catch::Matches(result));
+        REQUIRE(str == result);
+
+        str = IC_R(v0);
+        REQUIRE(str == result);
     }
 
     {
@@ -81,6 +84,9 @@ TEST_CASE("dump_string")
 
         IC(v0);
         REQUIRE(str == result);
+
+        str = IC_R(v0);
+        REQUIRE(str == result);
     }
 
     {
@@ -100,6 +106,9 @@ TEST_CASE("dump_string")
 
         IC(v0);
         REQUIRE(str == "ic| v0: {x: 1, y: 2, en: 1}\n");
+
+        str = IC_R(v0);
+        REQUIRE(str == "ic| v0: {x: 1, y: 2, en: 1}\n");
     }
 
     {
@@ -117,6 +126,9 @@ TEST_CASE("dump_string")
         };
 
         IC(v0);
+        REQUIRE(str == "ic| v0: {p: {x: 1, y: 2}, i: 7}\n");
+
+        str = IC_R(v0);
         REQUIRE(str == "ic| v0: {p: {x: 1, y: 2}, i: 7}\n");
     }
 

--- a/tests/test_disabled.cpp
+++ b/tests/test_disabled.cpp
@@ -34,6 +34,25 @@ TEST_CASE("printing")
     }
 
     {
+        auto str = IC_R(10);
+        REQUIRE(str.empty());
+        REQUIRE(std::is_same<decltype(IC_R(10)), std::string>::value);
+    }
+
+    {
+        auto str = IC_FR("#x", 10);
+        REQUIRE(str.empty());
+        REQUIRE(std::is_same<decltype(IC_FR("#x", 10)), std::string>::value);
+    }
+
+    {
+        auto v0 = int{1};
+        auto str = IC_FR("#x", v0, 10);
+        REQUIRE(str.empty());
+        REQUIRE(std::is_same<decltype(IC_FR("#x", v0, 10)), std::string>::value);
+    }
+
+    {
         IC_CONFIG_SCOPE();
         auto str = std::string{};
         IC_CONFIG.output(str);
@@ -50,6 +69,12 @@ TEST_CASE("printing")
         auto r = IC_F("#x", v0);
         REQUIRE(str.empty());
         REQUIRE(r == 1);
+    }
+
+    {
+        auto v0 = int{1};
+        auto str = IC_FR("#x", v0);
+        REQUIRE(str.empty());
     }
 
     {
@@ -75,6 +100,13 @@ TEST_CASE("printing")
       #endif
         REQUIRE(str.empty());
         REQUIRE(r == 50);
+    }
+
+    {
+        auto mc = MyClass{50};
+        auto str = IC_R(mc);
+        REQUIRE(str.empty());
+        REQUIRE(mc.ret_val() == 50);
     }
 
     {

--- a/tests/test_fmt.cpp
+++ b/tests/test_fmt.cpp
@@ -76,6 +76,9 @@ TEST_CASE("fmt lib")
 
         IC(v0);
         REQUIRE(str == result);
+
+        str = IC_R(v0);
+        REQUIRE(str == result);
     }
 
     {
@@ -93,6 +96,9 @@ TEST_CASE("fmt lib")
             "ic| \n"
             "    v0: [10, 20, 30, 40, 50, 60]\n";
         IC(v0);
+        REQUIRE(str == result);
+
+        str = IC_R(v0);
         REQUIRE(str == result);
     }
 
@@ -119,6 +125,9 @@ TEST_CASE("fmt lib")
 
         IC(v0);
         REQUIRE(str == result);
+
+        str = IC_R(v0);
+        REQUIRE(str == result);
     }
 
     {
@@ -135,6 +144,9 @@ TEST_CASE("fmt lib")
             "    v0: (10, 20, 30, 40, 50, 60)\n";
         IC(v0);
         REQUIRE(str == result);
+
+        str = IC_R(v0);
+        REQUIRE(str == result);
     }
 
     {
@@ -144,6 +156,9 @@ TEST_CASE("fmt lib")
 
         auto v0 = FmtFormatAs{5};
         IC(v0);
+        REQUIRE(str == "ic| v0: 5\n");
+
+        str = IC_R(v0);
         REQUIRE(str == "ic| v0: 5\n");
     }
 }

--- a/tests/test_slicing.cpp
+++ b/tests/test_slicing.cpp
@@ -38,6 +38,9 @@ TEST_CASE("bidirectional positive step")
         auto v0 = std::vector<int>{10, 11, 12, 13, 14};
         IC_F("[0:5:1]", v0);
         REQUIRE(str == "ic| v0: [0:5:1]->[10, 11, 12, 13, 14]\n");
+
+        str = IC_FR("[0:5:1]", v0);
+        REQUIRE(str == "ic| v0: [0:5:1]->[10, 11, 12, 13, 14]\n");
     }
 
     {
@@ -47,6 +50,9 @@ TEST_CASE("bidirectional positive step")
 
         auto v0 = std::vector<int>{10, 11, 12, 13, 14};
         IC_F("[0:5:]", v0);
+        REQUIRE(str == "ic| v0: [0:5:]->[10, 11, 12, 13, 14]\n");
+
+        str = IC_FR("[0:5:]", v0);
         REQUIRE(str == "ic| v0: [0:5:]->[10, 11, 12, 13, 14]\n");
     }
 
@@ -58,6 +64,9 @@ TEST_CASE("bidirectional positive step")
         auto v0 = std::vector<int>{10, 11, 12, 13, 14};
         IC_F("[-40:15:]", v0);
         REQUIRE(str == "ic| v0: [-40:15:]->[10, 11, 12, 13, 14]\n");
+
+        str = IC_FR("[-40:15:]", v0);
+        REQUIRE(str == "ic| v0: [-40:15:]->[10, 11, 12, 13, 14]\n");
     }
 
     {
@@ -67,6 +76,9 @@ TEST_CASE("bidirectional positive step")
 
         auto v0 = std::vector<int>{10, 11, 12, 13, 14};
         IC_F("[1:-2:]", v0);
+        REQUIRE(str == "ic| v0: [1:-2:]->[11, 12]\n");
+
+        str = IC_FR("[1:-2:]", v0);
         REQUIRE(str == "ic| v0: [1:-2:]->[11, 12]\n");
     }
 
@@ -78,6 +90,9 @@ TEST_CASE("bidirectional positive step")
         auto v0 = std::vector<int>{10, 11, 12, 13, 14};
         IC_F("[2:0:]", v0);
         REQUIRE(str == "ic| v0: [2:0:]->[]\n");
+
+        str = IC_FR("[2:0:]", v0);
+        REQUIRE(str == "ic| v0: [2:0:]->[]\n");
     }
 
     {
@@ -87,6 +102,9 @@ TEST_CASE("bidirectional positive step")
 
         auto v0 = std::vector<int>{10, 11, 12, 13, 14};
         IC_F("[0:3:2]", v0);
+        REQUIRE(str == "ic| v0: [0:3:2]->[10, 12]\n");
+
+        str = IC_FR("[0:3:2]", v0);
         REQUIRE(str == "ic| v0: [0:3:2]->[10, 12]\n");
     }
 
@@ -98,6 +116,9 @@ TEST_CASE("bidirectional positive step")
         auto v0 = std::vector<int>{10, 11, 12, 13, 14};
         IC_F("[:]", v0);
         REQUIRE(str == "ic| v0: [:]->[10, 11, 12, 13, 14]\n");
+
+        str = IC_FR("[:]", v0);
+        REQUIRE(str == "ic| v0: [:]->[10, 11, 12, 13, 14]\n");
     }
 
     {
@@ -107,6 +128,9 @@ TEST_CASE("bidirectional positive step")
 
         auto v0 = std::vector<int>{10, 11, 12, 13, 14};
         IC_F("[::]", v0);
+        REQUIRE(str == "ic| v0: [::]->[10, 11, 12, 13, 14]\n");
+
+        str = IC_FR("[::]", v0);
         REQUIRE(str == "ic| v0: [::]->[10, 11, 12, 13, 14]\n");
     }
 
@@ -118,6 +142,9 @@ TEST_CASE("bidirectional positive step")
         auto v0 = std::vector<int>{10, 11, 12, 13, 14};
         IC_F("[3:]", v0);
         REQUIRE(str == "ic| v0: [3:]->[13, 14]\n");
+
+        str = IC_FR("[3:]", v0);
+        REQUIRE(str == "ic| v0: [3:]->[13, 14]\n");
     }
 
     {
@@ -128,6 +155,9 @@ TEST_CASE("bidirectional positive step")
         auto v0 = std::vector<int>{10, 11, 12, 13, 14};
         IC_F("[:3]", v0);
         REQUIRE(str == "ic| v0: [:3]->[10, 11, 12]\n");
+
+        str = IC_FR("[:3]", v0);
+        REQUIRE(str == "ic| v0: [:3]->[10, 11, 12]\n");
     }
 
     {
@@ -137,6 +167,9 @@ TEST_CASE("bidirectional positive step")
 
         auto v0 = std::vector<int>{10, 11, 12, 13, 14};
         IC_F("[:-1]", v0);
+        REQUIRE(str == "ic| v0: [:-1]->[10, 11, 12, 13]\n");
+
+        str = IC_FR("[:-1]", v0);
         REQUIRE(str == "ic| v0: [:-1]->[10, 11, 12, 13]\n");
     }
 }
@@ -152,6 +185,9 @@ TEST_CASE("bidirectional negative step")
         auto v0 = std::vector<int>{10, 11, 12, 13, 14};
         IC_F("[4:0:-1]", v0);
         REQUIRE(str == "ic| v0: [4:0:-1]->[14, 13, 12, 11]\n");
+
+        str = IC_FR("[4:0:-1]", v0);
+        REQUIRE(str == "ic| v0: [4:0:-1]->[14, 13, 12, 11]\n");
     }
 
     {
@@ -161,6 +197,9 @@ TEST_CASE("bidirectional negative step")
 
         auto v0 = std::vector<int>{10, 11, 12, 13, 14};
         IC_F("[4:-5:-1]", v0);
+        REQUIRE(str == "ic| v0: [4:-5:-1]->[14, 13, 12, 11]\n");
+
+        str = IC_FR("[4:-5:-1]", v0);
         REQUIRE(str == "ic| v0: [4:-5:-1]->[14, 13, 12, 11]\n");
     }
 
@@ -172,6 +211,9 @@ TEST_CASE("bidirectional negative step")
         auto v0 = std::vector<int>{10, 11, 12, 13, 14};
         IC_F("[-1:-6:-1]", v0);
         REQUIRE(str == "ic| v0: [-1:-6:-1]->[14, 13, 12, 11, 10]\n");
+
+        str = IC_FR("[-1:-6:-1]", v0);
+        REQUIRE(str == "ic| v0: [-1:-6:-1]->[14, 13, 12, 11, 10]\n");
     }
 
     {
@@ -181,6 +223,9 @@ TEST_CASE("bidirectional negative step")
 
         auto v0 = std::vector<int>{10, 11, 12, 13, 14};
         IC_F("[20:-15:-1]", v0);
+        REQUIRE(str == "ic| v0: [20:-15:-1]->[14, 13, 12, 11, 10]\n");
+
+        str = IC_FR("[20:-15:-1]", v0);
         REQUIRE(str == "ic| v0: [20:-15:-1]->[14, 13, 12, 11, 10]\n");
     }
 
@@ -192,6 +237,9 @@ TEST_CASE("bidirectional negative step")
         auto v0 = std::vector<int>{10, 11, 12, 13, 14};
         IC_F("[0:2:-1]", v0);
         REQUIRE(str == "ic| v0: [0:2:-1]->[]\n");
+
+        str = IC_FR("[0:2:-1]", v0);
+        REQUIRE(str == "ic| v0: [0:2:-1]->[]\n");
     }
 
     {
@@ -201,6 +249,9 @@ TEST_CASE("bidirectional negative step")
 
         auto v0 = std::vector<int>{10, 11, 12, 13, 14};
         IC_F("[0:-2:-1]", v0);
+        REQUIRE(str == "ic| v0: [0:-2:-1]->[]\n");
+
+        str = IC_FR("[0:-2:-1]", v0);
         REQUIRE(str == "ic| v0: [0:-2:-1]->[]\n");
     }
 
@@ -212,6 +263,9 @@ TEST_CASE("bidirectional negative step")
         auto v0 = std::vector<int>{10, 11, 12, 13, 14};
         IC_F("[-1:0:-2]", v0);
         REQUIRE(str == "ic| v0: [-1:0:-2]->[14, 12]\n");
+
+        str = IC_FR("[-1:0:-2]", v0);
+        REQUIRE(str == "ic| v0: [-1:0:-2]->[14, 12]\n");
     }
 
     {
@@ -221,6 +275,9 @@ TEST_CASE("bidirectional negative step")
 
         auto v0 = std::vector<int>{10, 11, 12, 13, 14};
         IC_F("[::-1]", v0);
+        REQUIRE(str == "ic| v0: [::-1]->[14, 13, 12, 11, 10]\n");
+
+        str = IC_FR("[::-1]", v0);
         REQUIRE(str == "ic| v0: [::-1]->[14, 13, 12, 11, 10]\n");
     }
 
@@ -232,6 +289,9 @@ TEST_CASE("bidirectional negative step")
         auto v0 = std::vector<int>{10, 11, 12, 13, 14};
         IC_F("[2::-1]", v0);
         REQUIRE(str == "ic| v0: [2::-1]->[12, 11, 10]\n");
+
+        str = IC_FR("[2::-1]", v0);
+        REQUIRE(str == "ic| v0: [2::-1]->[12, 11, 10]\n");
     }
 
     {
@@ -241,6 +301,9 @@ TEST_CASE("bidirectional negative step")
 
         auto v0 = std::vector<int>{10, 11, 12, 13, 14};
         IC_F("[:-3:-1]", v0);
+        REQUIRE(str == "ic| v0: [:-3:-1]->[14, 13]\n");
+
+        str = IC_FR("[:-3:-1]", v0);
         REQUIRE(str == "ic| v0: [:-3:-1]->[14, 13]\n");
     }
 }
@@ -256,6 +319,9 @@ TEST_CASE("bidirectional - wrong formatting")
         auto v0 = std::vector<int>{10, 11, 12, 13, 14};
         IC_F("[a:5:1]", v0);
         REQUIRE(str == "ic| v0: <invalid range slicing>\n");
+
+        str = IC_FR("[a:5:1]", v0);
+        REQUIRE(str == "ic| v0: <invalid range slicing>\n");
     }
 
     {
@@ -265,6 +331,9 @@ TEST_CASE("bidirectional - wrong formatting")
 
         auto v0 = std::vector<int>{10, 11, 12, 13, 14};
         IC_F("[]", v0);
+        REQUIRE(str == "ic| v0: <invalid range slicing>\n");
+
+        str = IC_FR("[]", v0);
         REQUIRE(str == "ic| v0: <invalid range slicing>\n");
     }
 
@@ -276,6 +345,9 @@ TEST_CASE("bidirectional - wrong formatting")
         auto v0 = std::vector<int>{10, 11, 12, 13, 14};
         IC_F("[:::]", v0);
         REQUIRE(str == "ic| v0: <invalid range slicing>\n");
+
+        str = IC_FR("[:::]", v0);
+        REQUIRE(str == "ic| v0: <invalid range slicing>\n");
     }
 
     {
@@ -285,6 +357,9 @@ TEST_CASE("bidirectional - wrong formatting")
 
         auto v0 = std::vector<int>{10, 11, 12, 13, 14};
         IC_F("[::0]", v0);
+        REQUIRE(str == "ic| v0: <slice step cannot be zero>\n");
+
+        str = IC_FR("[::0]", v0);
         REQUIRE(str == "ic| v0: <slice step cannot be zero>\n");
     }
 }
@@ -300,6 +375,9 @@ TEST_CASE("forward unknown size")
         auto v0 = std::forward_list<int>{10, 11, 12, 13, 14};
         IC_F("[0:5:1]", v0);
         REQUIRE(str == "ic| v0: [0:5:1]->[10, 11, 12, 13, 14]\n");
+
+        str = IC_FR("[0:5:1]", v0);
+        REQUIRE(str == "ic| v0: [0:5:1]->[10, 11, 12, 13, 14]\n");
     }
 
     {
@@ -309,6 +387,9 @@ TEST_CASE("forward unknown size")
 
         auto v0 = std::forward_list<int>{10, 11, 12, 13, 14};
         IC_F("[0:3:1]", v0);
+        REQUIRE(str == "ic| v0: [0:3:1]->[10, 11, 12]\n");
+
+        str = IC_FR("[0:3:1]", v0);
         REQUIRE(str == "ic| v0: [0:3:1]->[10, 11, 12]\n");
     }
 
@@ -320,6 +401,9 @@ TEST_CASE("forward unknown size")
         auto v0 = std::forward_list<int>{10, 11, 12, 13, 14};
         IC_F("[:2]", v0);
         REQUIRE(str == "ic| v0: [:2]->[10, 11]\n");
+
+        str = IC_FR("[:2]", v0);
+        REQUIRE(str == "ic| v0: [:2]->[10, 11]\n");
     }
 
     {
@@ -329,6 +413,9 @@ TEST_CASE("forward unknown size")
 
         auto v0 = std::forward_list<int>{10, 11, 12, 13, 14};
         IC_F("[:]", v0);
+        REQUIRE(str == "ic| v0: [:]->[10, 11, 12, 13, 14]\n");
+
+        str = IC_FR("[:]", v0);
         REQUIRE(str == "ic| v0: [:]->[10, 11, 12, 13, 14]\n");
     }
 
@@ -340,6 +427,9 @@ TEST_CASE("forward unknown size")
         auto v0 = std::forward_list<int>{10, 11, 12, 13, 14};
         IC_F("[::2]", v0);
         REQUIRE(str == "ic| v0: [::2]->[10, 12, 14]\n");
+
+        str = IC_FR("[::2]", v0);
+        REQUIRE(str == "ic| v0: [::2]->[10, 12, 14]\n");
     }
 
     {
@@ -350,6 +440,9 @@ TEST_CASE("forward unknown size")
         auto v0 = std::forward_list<int>{10, 11, 12, 13, 14};
         IC_F("[0:15:1]", v0);
         REQUIRE(str == "ic| v0: [0:15:1]->[10, 11, 12, 13, 14]\n");
+
+        str = IC_FR("[0:15:1]", v0);
+        REQUIRE(str == "ic| v0: [0:15:1]->[10, 11, 12, 13, 14]\n");
     }
 
     {
@@ -359,6 +452,9 @@ TEST_CASE("forward unknown size")
 
         auto v0 = std::forward_list<int>{10, 11, 12, 13, 14};
         IC_F("[3]", v0);
+        REQUIRE(str == "ic| v0: [3]->[13]\n");
+
+        str = IC_FR("[3]", v0);
         REQUIRE(str == "ic| v0: [3]->[13]\n");
     }
 }
@@ -374,6 +470,9 @@ TEST_CASE("forward unknown size - wrong formatting")
         auto v0 = std::forward_list<int>{10, 11, 12, 13, 14};
         IC_F("[-1]", v0);
         REQUIRE(str == "ic| \n    v0: <this range supports only non-negative start and stop slice indexes>\n");
+
+        str = IC_FR("[-1]", v0);
+        REQUIRE(str == "ic| \n    v0: <this range supports only non-negative start and stop slice indexes>\n");
     }
 
     {
@@ -384,6 +483,9 @@ TEST_CASE("forward unknown size - wrong formatting")
         auto v0 = std::forward_list<int>{10, 11, 12, 13, 14};
         IC_F("[::-1]", v0);
         REQUIRE(str == "ic| v0: <this range supports only strictly positive slice steps>\n");
+
+        str = IC_FR("[::-1]", v0);
+        REQUIRE(str == "ic| v0: <this range supports only strictly positive slice steps>\n");
     }
 
     {
@@ -393,6 +495,9 @@ TEST_CASE("forward unknown size - wrong formatting")
 
         auto v0 = std::forward_list<int>{10, 11, 12, 13, 14};
         IC_F("[::0]", v0);
+        REQUIRE(str == "ic| v0: <slice step cannot be zero>\n");
+
+        str = IC_FR("[::0]", v0);
         REQUIRE(str == "ic| v0: <slice step cannot be zero>\n");
     }
 }
@@ -408,6 +513,9 @@ TEST_CASE("forward known size")
         auto v0 = SizedForwardList{10, 11, 12, 13, 14};
         IC_F("[0:5:1]", v0);
         REQUIRE(str == "ic| v0: [0:5:1]->[10, 11, 12, 13, 14]\n");
+
+        str = IC_FR("[0:5:1]", v0);
+        REQUIRE(str == "ic| v0: [0:5:1]->[10, 11, 12, 13, 14]\n");
     }
 
     {
@@ -417,6 +525,9 @@ TEST_CASE("forward known size")
 
         auto v0 = SizedForwardList{10, 11, 12, 13, 14};
         IC_F("[0:3:1]", v0);
+        REQUIRE(str == "ic| v0: [0:3:1]->[10, 11, 12]\n");
+
+        str = IC_FR("[0:3:1]", v0);
         REQUIRE(str == "ic| v0: [0:3:1]->[10, 11, 12]\n");
     }
 
@@ -428,6 +539,9 @@ TEST_CASE("forward known size")
         auto v0 = SizedForwardList{10, 11, 12, 13, 14};
         IC_F("[0::3]", v0);
         REQUIRE(str == "ic| v0: [0::3]->[10, 13]\n");
+
+        str = IC_FR("[0::3]", v0);
+        REQUIRE(str == "ic| v0: [0::3]->[10, 13]\n");
     }
 
     {
@@ -437,6 +551,9 @@ TEST_CASE("forward known size")
 
         auto v0 = SizedForwardList{10, 11, 12, 13, 14};
         IC_F("[0:-3]", v0);
+        REQUIRE(str == "ic| v0: [0:-3]->[10, 11]\n");
+
+        str = IC_FR("[0:-3]", v0);
         REQUIRE(str == "ic| v0: [0:-3]->[10, 11]\n");
     }
 
@@ -448,6 +565,9 @@ TEST_CASE("forward known size")
         auto v0 = SizedForwardList{10, 11, 12, 13, 14};
         IC_F("[-3:-1]", v0);
         REQUIRE(str == "ic| v0: [-3:-1]->[12, 13]\n");
+
+        str = IC_FR("[-3:-1]", v0);
+        REQUIRE(str == "ic| v0: [-3:-1]->[12, 13]\n");
     }
 
     {
@@ -457,6 +577,9 @@ TEST_CASE("forward known size")
 
         auto v0 = SizedForwardList{10, 11, 12, 13, 14};
         IC_F("[:2]", v0);
+        REQUIRE(str == "ic| v0: [:2]->[10, 11]\n");
+
+        str = IC_FR("[:2]", v0);
         REQUIRE(str == "ic| v0: [:2]->[10, 11]\n");
     }
 
@@ -468,6 +591,9 @@ TEST_CASE("forward known size")
         auto v0 = SizedForwardList{10, 11, 12, 13, 14};
         IC_F("[:]", v0);
         REQUIRE(str == "ic| v0: [:]->[10, 11, 12, 13, 14]\n");
+
+        str = IC_FR("[:]", v0);
+        REQUIRE(str == "ic| v0: [:]->[10, 11, 12, 13, 14]\n");
     }
 
     {
@@ -477,6 +603,9 @@ TEST_CASE("forward known size")
 
         auto v0 = SizedForwardList{10, 11, 12, 13, 14};
         IC_F("[::2]", v0);
+        REQUIRE(str == "ic| v0: [::2]->[10, 12, 14]\n");
+
+        str = IC_FR("[::2]", v0);
         REQUIRE(str == "ic| v0: [::2]->[10, 12, 14]\n");
     }
 
@@ -488,6 +617,9 @@ TEST_CASE("forward known size")
         auto v0 = SizedForwardList{10, 11, 12, 13, 14};
         IC_F("[0:15:1]", v0);
         REQUIRE(str == "ic| v0: [0:15:1]->[10, 11, 12, 13, 14]\n");
+
+        str = IC_FR("[0:15:1]", v0);
+        REQUIRE(str == "ic| v0: [0:15:1]->[10, 11, 12, 13, 14]\n");
     }
 
     {
@@ -498,6 +630,9 @@ TEST_CASE("forward known size")
         auto v0 = SizedForwardList{10, 11, 12, 13, 14};
         IC_F("[3]", v0);
         REQUIRE(str == "ic| v0: [3]->[13]\n");
+
+        str = IC_FR("[3]", v0);
+        REQUIRE(str == "ic| v0: [3]->[13]\n");
     }
 
     {
@@ -507,6 +642,9 @@ TEST_CASE("forward known size")
 
         auto v0 = SizedForwardList{10, 11, 12, 13, 14};
         IC_F("[-3]", v0);
+        REQUIRE(str == "ic| v0: [-3]->[12]\n");
+
+        str = IC_FR("[-3]", v0);
         REQUIRE(str == "ic| v0: [-3]->[12]\n");
     }
 }
@@ -522,6 +660,9 @@ TEST_CASE("forward known size - wrong formatting")
         auto v0 = SizedForwardList{10, 11, 12, 13, 14};
         IC_F("[::-1]", v0);
         REQUIRE(str == "ic| v0: <this range supports only strictly positive slice steps>\n");
+
+        str = IC_FR("[::-1]", v0);
+        REQUIRE(str == "ic| v0: <this range supports only strictly positive slice steps>\n");
     }
 
     {
@@ -531,6 +672,9 @@ TEST_CASE("forward known size - wrong formatting")
 
         auto v0 = SizedForwardList{10, 11, 12, 13, 14};
         IC_F("[::0]", v0);
+        REQUIRE(str == "ic| v0: <slice step cannot be zero>\n");
+
+        str = IC_FR("[::0]", v0);
         REQUIRE(str == "ic| v0: <slice step cannot be zero>\n");
     }
 }

--- a/tests/test_strings_c++17.cpp
+++ b/tests/test_strings_c++17.cpp
@@ -21,6 +21,9 @@ TEST_CASE("std_string_view")
         auto v0 = std::string_view {"str 1"};
         IC(v0);
         REQUIRE(str == "ic| v0: \"str 1\"\n");
+
+        str = IC_R(v0);
+        REQUIRE(str == "ic| v0: \"str 1\"\n");
     }
 
     {
@@ -32,6 +35,9 @@ TEST_CASE("std_string_view")
         auto v1 = std::string_view {v0.data() + 1, 3};
         IC(v1);
         REQUIRE(str == "ic| v1: \"BCD\"\n");
+
+        str = IC_R(v1);
+        REQUIRE(str == "ic| v1: \"BCD\"\n");
     }
 
     {
@@ -42,6 +48,9 @@ TEST_CASE("std_string_view")
         auto v0 = std::wstring_view {L"wstr 1"};
         IC(v0);
         REQUIRE(str == "ic| v0: \"wstr 1\"\n");
+
+        str = IC_R(v0);
+        REQUIRE(str == "ic| v0: \"wstr 1\"\n");
     }
 
     {
@@ -51,6 +60,9 @@ TEST_CASE("std_string_view")
 
         auto v0 = std::u16string_view {u"u16str \u03B1"};
         IC(v0);
+        REQUIRE(str == "ic| v0: \"u16str \xce\xb1\"\n");
+
+        str = IC_R(v0);
         REQUIRE(str == "ic| v0: \"u16str \xce\xb1\"\n");
     }
 
@@ -64,6 +76,9 @@ TEST_CASE("std_string_view")
         auto v0 = std::u16string_view(v);
         IC(v0);
         REQUIRE(str == "ic| v0: \"u16str\\x{d801}\"\n");
+
+        str = IC_R(v0);
+        REQUIRE(str == "ic| v0: \"u16str\\x{d801}\"\n");
     }
 
     {
@@ -73,6 +88,9 @@ TEST_CASE("std_string_view")
 
         auto v0 = std::u32string_view {U"u32str \U0001F427"};
         IC(v0);
+        REQUIRE(str == "ic| v0: \"u32str \xF0\x9F\x90\xA7\"\n");
+
+        str = IC_R(v0);
         REQUIRE(str == "ic| v0: \"u32str \xF0\x9F\x90\xA7\"\n");
     }
 }
@@ -96,6 +114,9 @@ TEST_CASE("transcode functions")
         char16_t const* v0 = u"char16_t test \u03B1";
         IC_F("s", v0);
         REQUIRE(str == "ic| v0: foo\n");
+
+        str = IC_FR("s", v0);
+        REQUIRE(str == "ic| v0: foo\n");
     }
 
     {
@@ -113,6 +134,9 @@ TEST_CASE("transcode functions")
 
         auto v0 = std::wstring_view(L"wide string test");
         IC(v0);
+        REQUIRE(str == "ic| v0: \"qux\"\n");
+
+        str = IC_R(v0);
         REQUIRE(str == "ic| v0: \"qux\"\n");
     }
 }

--- a/tests/test_strings_c++20.cpp
+++ b/tests/test_strings_c++20.cpp
@@ -21,6 +21,9 @@ TEST_CASE("char8_t")
         auto v0 = char8_t {u8'a'};
         IC(v0);
         REQUIRE(str == "ic| v0: 'a'\n");
+
+        str = IC_R(v0);
+        REQUIRE(str == "ic| v0: 'a'\n");
     }
 
     {
@@ -30,6 +33,9 @@ TEST_CASE("char8_t")
 
         auto v0 = char8_t {u8'a'};
         IC_F("#o", v0);
+        REQUIRE(str == "ic| v0: 0141\n");
+
+        str = IC_FR("#o", v0);
         REQUIRE(str == "ic| v0: 0141\n");
     }
 
@@ -41,6 +47,9 @@ TEST_CASE("char8_t")
         auto v0 = char8_t{0x80};  // invalid UTF-8 code unit
         IC(v0);
         REQUIRE(str == "ic| v0: '\\x{80}'\n");
+
+        str = IC_R(v0);
+        REQUIRE(str == "ic| v0: '\\x{80}'\n");
     }
 
     {
@@ -50,6 +59,9 @@ TEST_CASE("char8_t")
 
         auto v0 = char8_t{0x80};  // invalid UTF-8 code unit
         IC_F("c", v0);
+        REQUIRE(str == "ic| v0: �\n");
+
+        str = IC_FR("c", v0);
         REQUIRE(str == "ic| v0: �\n");
     }
 
@@ -61,6 +73,9 @@ TEST_CASE("char8_t")
         auto v0 = std::u8string {u8"u8str \uAB8C"}; // Cherokee Small Letter MO
         IC(v0);
         REQUIRE(str == "ic| v0: \"u8str \xEA\xAE\x8C\"\n");
+
+        str = IC_R(v0);
+        REQUIRE(str == "ic| v0: \"u8str \xEA\xAE\x8C\"\n");
     }
 
     {
@@ -71,6 +86,9 @@ TEST_CASE("char8_t")
         char8_t const* const v0 = u8"char8_t test \uAB8C";
         IC(v0);
         REQUIRE(str == "ic| v0: \"char8_t test \xEA\xAE\x8C\"\n");
+
+        str = IC_R(v0);
+        REQUIRE(str == "ic| v0: \"char8_t test \xEA\xAE\x8C\"\n");
     }
 
     {
@@ -80,6 +98,9 @@ TEST_CASE("char8_t")
 
         auto v0 = std::u8string_view {u8"u8str \uAB8C"}; // Cherokee Small Letter MO
         IC(v0);
+        REQUIRE(str == "ic| v0: \"u8str \xEA\xAE\x8C\"\n");
+
+        str = IC_R(v0);
         REQUIRE(str == "ic| v0: \"u8str \xEA\xAE\x8C\"\n");
     }
 }
@@ -104,6 +125,9 @@ TEST_CASE("transcode functions")
         char8_t const* v0 = u8"char8_t test A";
         IC_F("s", v0);
         REQUIRE(str == "ic| v0: foo\n");
+
+        str = IC_FR("s", v0);
+        REQUIRE(str == "ic| v0: foo\n");
     }
 
     {
@@ -121,6 +145,9 @@ TEST_CASE("transcode functions")
 
         auto v0 = std::u8string_view{u8"string B"};
         IC_F("s", v0);
+        REQUIRE(str == "ic| v0: foo\n");
+
+        str = IC_FR("s", v0);
         REQUIRE(str == "ic| v0: foo\n");
     }
 }


### PR DESCRIPTION
I wanted to combine the formatting capabilities of IceCream with`{fmt}` and be able to quickly output and format objects. Since IceCream does not support `"{} {}"` formatting, such formatting can be created with `IC_R` (return) and `IC_FR` (format and return):

```c++
auto v = std::vector<int>{10, 11, 12, 13, 14};
auto str = IC_R(v);  // ic| v: [10, 11, 12, 13, 14]
```
```c++
auto str = IC_FR("[0:2]", v);  // ic| v: [10, 11, 12]
```
```c++
IC_CONFIG.prefix("");
auto v = std::vector<int>{10, 11, 12, 13, 14};
auto i = 21;
fmt::print("Pushing {} to the {}", IC_FR("#x", i), IC_R(v))
// Pushing i: 0x15 to the v: [10, 11, 12, 13, 14]
```
```c++
IC_CONFIG.prefix("");
S s = {3.14, {1,2,3}};    
fmt::print("Testing class {}", IC_R(s));  
// Testing class s: {f: 3.14, ii: [1, 2, 3]}
```

I'm trying to reuse IceCream formatting without rewriting anything. The macros passed local tests successfully, and I used them in my projects.
