### PR TITLE
Improve README documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,76 +3,32 @@
 [![CI.badge]][CI.link]
 [![LICENSE.badge]][LICENSE.link]
 
-Icecream-cpp is a little (single header) library to help with the print debugging in C++11
-and forward.
+Icecream-cpp is a little (single header) library to help with print debugging in C++11 and
+later.
 
 [Try it at Compiler Explorer!](https://godbolt.org/z/WKbxejjaa)
 
 
-**Contents**
-* [Rationale](#rationale)
-* [Install](#install)
-  * [Conan](#conan)
-  * [Nix](#nix)
-* [Usage](#usage)
-  * [Direct printing](#direct-printing)
-  * [Range views pipeline](#range-views-pipeline)
-  * [Return value and Icecream apply macro](#return-value-and-icecream-apply-macro)
-  * [Output formatting](#output-formatting)
-  * [C strings](#c-strings)
-  * [Character Encoding](#character-encoding)
-  * [Macro disabling](#macro-disabling)
-  * [Configuration](#configuration)
-     * [enable/disable](#enabledisable)
-     * [output](#output)
-     * [prefix](#prefix)
-     * [show_c_string](#show_c_string)
-     * [decay_char_array](#decay_char_array)
-     * [force_range_strategy](#force_range_strategy)
-     * [force_tuple_strategy](#force_tuple_strategy)
-     * [force_variant_strategy](#force_variant_strategy)
-     * [wide_string_transcoder](#wide_string_transcoder)
-     * [unicode_transcoder](#unicode_transcoder)
-     * [output_transcoder](#output_transcoder)
-     * [line_wrap_width](#line_wrap_width)
-     * [include_context](#include_context)
-     * [context_delimiter](#context_delimiter)
-  * [Printing strategies](#printing-strategies)
-     * [IOStreams](#iostreams)
-     * [Formatting library](#formatting-library)
-     * [{fmt}](#fmt-1)
-     * [Characters](#characters)
-     * [Strings](#strings)
-     * [Pointer like types](#pointer-like-types)
-     * [Range types](#range-types)
-     * [Tuple like types](#tuple-like-types)
-     * [Optional types](#optional-types)
-     * [Variant types](#variant-types)
-     * [Exception types](#exception-types)
-     * [Clang dump struct](#clang-dump-struct)
-  * [Third-party libraries](#third-party-libraries)
-* [Pitfalls](#pitfalls)
-
-With Icecream-cpp, an execution inspection:
+Tracking execution flow:
 
 ```c++
-auto my_function(int i, double d) -> void
+auto roll_attack(int roll) -> void
 {
-    std::cout << "1" << std::endl;
-    if (condition)
-        std::cout << "2" << std::endl;
+    std::cout << "entered roll_attack" << std::endl;
+    if (roll == 20)
+        std::cout << "critical hit branch" << std::endl;
     else
-        std::cout << "3" << std::endl;
+        std::cout << "normal hit branch" << std::endl;
 }
 ```
 
 can be [coded instead](#direct-printing):
 
 ```c++
-auto my_function(int i, double d) -> void
+auto roll_attack(int roll) -> void
 {
     IC();
-    if (condition)
+    if (roll == 20)
         IC();
     else
         IC();
@@ -81,10 +37,10 @@ auto my_function(int i, double d) -> void
 
 and will print something like:
 
-    ic| test.cpp:34 in "void my_function(int, double)"
-    ic| test.cpp:36 in "void my_function(int, double)"
+    ic| combat.cpp:12 in "void roll_attack(int)"
+    ic| combat.cpp:14 in "void roll_attack(int)"
 
-Also, any variable inspection like:
+Inspecting variables:
 
 ```c++
 std::cout << "a: " << a
@@ -103,10 +59,38 @@ and will print:
 
     ic| a: 7, b: 2, sum(a, b): 9
 
-We also can inspect the data flowing through a range views pipeline (both [STL
-ranges](https://en.cppreference.com/w/cpp/header/ranges) and
-[Range-v3](https://ericniebler.github.io/range-v3/)), by inserting a
-[`IC_V()`](#range-views-pipeline) function at the point of interest:
+[Formatting output](#output-formatting). Instead of:
+
+```c++
+auto answer = int{42};
+auto num = int{10};
+std::cout << "answer: 0x" << std::hex << answer << ", num: 0x" << num << std::endl;
+```
+
+just write:
+
+```c++
+IC_F("#x", answer, num);
+```
+
+and get:
+
+    ic| answer: 0x2a, num: 0xa
+
+Slicing ranges [like in Python](#range-format-string):
+
+```c++
+auto v = std::vector<char32_t>{U'α', U'β', U'γ', U'δ', U'ε', U'ζ'};
+IC_F("[1:-2]", v);
+```
+
+will print:
+
+    ic| v: [1:-2]->['β', 'γ', 'δ']
+
+Debugging range pipelines. Insert [`IC_V()`](#range-views-pipeline) to inspect data
+flowing through [STL ranges](https://en.cppreference.com/w/cpp/header/ranges) or
+[Range-v3](https://ericniebler.github.io/range-v3/) pipelines:
 
 ```c++
 auto rv = std::vector<int>{1, 0, 2, 3, 0, 4, 5}
@@ -115,51 +99,53 @@ auto rv = std::vector<int>{1, 0, 2, 3, 0, 4, 5}
     | vws::enumerate;
 ```
 
-So that when we iterate on `rv`, we will see the printing:
+When iterating on `rv`, we will see:
 
     ic| range_view_63:16[0]: [1]
     ic| range_view_63:16[1]: [2, 3]
     ic| range_view_63:16[2]: [4, 5]
 
-
-And as a last example, we can easily [format the printing output](#output-formatting):
-
-```c++
-auto i = int{42};
-IC_F("#x", i);
-auto v = std::vector<char8_t>{'a', 'b', 'c', 'd', 'e', 'f'};
-IC_F("[1:-2]", v);
-```
-
-will print:
-
-```
-ic| i: 0x2a
-ic| v: [1:-2]->['b', 'c', 'd']
-```
-
 This library was inspired by the original [Python
 IceCream](https://github.com/gruns/icecream) library.
 
+
+**Contents**
+* [Rationale](#rationale)
+* [Install](#install)
+  * [Quick Start](#quick-start)
+* [Basic Usage](#basic-usage)
+  * [Direct printing](#direct-printing)
+  * [Range views pipeline](#range-views-pipeline)
+  * [Return value and Icecream apply macro](#return-value-and-icecream-apply-macro)
+  * [Output formatting](#output-formatting)
+* [Configuration](#configuration)
+* [Printing Strategies](#printing-strategies)
+* [Third-party Libraries](#third-party-libraries)
+* [Compatibility](#compatibility)
+* [Reference](#reference)
+  * [C strings](#c-strings)
+  * [Character Encoding](#character-encoding)
+  * [Macro disabling](#macro-disabling)
+* [Pitfalls](#pitfalls)
+
+
 ## Rationale
 
-The Icecream-cpp is a throw off library. It is designed to be used when writing code and
-debugging it, it was not designed to go along with the released product.
+Icecream-cpp is a throwaway library. It is designed for use during development and
+debugging, not for shipping with the released product. It complements debuggers rather
+than replacing them, sometimes print debugging is simply faster or more practical.
 
-Because of these design decisions, the Icecream-cpp library perhaps is one of the few
-libraries that you should spend more time writing code with it than reading code with it.
-With that in mind, we have as design goals: expressivity and conciseness. It should be
-possible to print the value of any variable, formatted as desired, and writing the code to
-achieve that should be as easy and short as possible.
+Because of this, Icecream-cpp is one of the few libraries where you will spend more time
+writing code with it than reading code with it. Our design goals are expressivity and
+conciseness: print any variable, format it as desired, with as little code as possible.
+
 
 ## Install
 
-The Icecream-cpp is a one file, header only library, having the STL as its only
-dependency. The most immediate way to use it is just copy the `icecream.hpp` header into
-your project.
+Icecream-cpp is a single-file, header-only library with only the STL as dependency. The
+simplest way to use it is to copy `icecream.hpp` into your project.
 
-To properly install it system wide, together with the CMake project files, run these
-commands at Icecream-cpp project root directory:
+To install system-wide with CMake support, run from the project root:
 
 ```Shell
 mkdir build
@@ -170,19 +156,18 @@ cmake --install .
 
 ### Conan
 
-The released versions are available on [Conan](https://conan.io/center/recipes/icecream-cpp) too:
-
-[Here](example_project/conanfile.txt) we also have an example of a `conanfile.txt` which
-requires Icecream-cpp.
+Released versions are available on
+[Conan](https://conan.io/center/recipes/icecream-cpp). See
+[example_project/conanfile.txt](example_project/conanfile.txt) for a usage example.
 
 ### Nix
 
-If using [Nix](https://nixos.org), Icecream-cpp can be included as a flakes input as
+Icecream-cpp can be included as a flakes input:
 ```Nix
 inputs.icecream-cpp.url = "github:renatoGarcia/icecream-cpp";
 ```
 
-The Icecream-cpp flake defines an overlay, so that it can be used when importing `nixpkgs`:
+The flake defines an overlay for use when importing `nixpkgs`:
 ```Nix
 import nixpkgs {
   system = "x86_64-linux";
@@ -191,38 +176,46 @@ import nixpkgs {
   ];
 }
 ```
-Doing this, an `icecream-cpp` derivation will be added to the `nixpkgs` attribute set.
+This adds an `icecream-cpp` derivation to the `nixpkgs` attribute set.
 
-A working example of how to use Icecream-cpp in a flake project is available
-[here](example_project/flake.nix).
+See [example_project/flake.nix](example_project/flake.nix) for a working example.
 
+### Quick Start
 
-## Usage
-
-If using CMake:
+With CMake:
 ```CMake
 find_package(icecream-cpp)
 target_link_libraries(<target> PRIVATE icecream-cpp::icecream-cpp)
 ```
 Where `<target>` is the executable or library being compiled.
 
-After including the `icecream.hpp` header in a source file:
+Then include the header:
 
 ```C++
 #include <icecream.hpp>
+
+int main(int, char*[])
+{
+    auto x = 42;
+    auto name = std::string{"foo"};
+    IC(x, name);  // prints: ic| x: 42, name: "foo"
+    return 0;
+}
 ```
 
-all the functionalities of Icecream-cpp library will be available by the functions
-[`IC`](#direct-printing), [`IC_A`](#return-value-and-icecream-apply-macro), and
-[`IC_V`](#range-views-pipeline); together with its respective counterparts `IC_F`,
-`IC_FA`, and `IC_FV`; that behave the same but accept an [output formatting
-string](#output-formatting) as its first argument.
+
+## Basic Usage
+
+The main Icecream-cpp functions are [`IC`](#direct-printing),
+[`IC_A`](#return-value-and-icecream-apply-macro), and [`IC_V`](#range-views-pipeline);
+together with their respective counterparts `IC_F`, `IC_FA`, and `IC_FV`; that behave the
+same but accept an [output formatting string](#output-formatting) as their first argument.
 
 
 ### Direct printing
 
-The `IC` is the simplest of the Icecream-cpp functions. If called with no arguments it
-will print the [prefix](#prefix), the source file name, the current line number, and the
+`IC` is the simplest of the Icecream-cpp functions. If called with no arguments it will
+print the [prefix](#prefix), the source file name, the current line number, and the
 current function signature. The code:
 
 ```C++
@@ -238,8 +231,8 @@ will print:
 
     ic| test.cpp:34 in "void my_function(int, double)"
 
-If called with arguments it will print the [prefix](#prefix), those arguments names, and
-its values.  The code:
+If called with arguments it will print the [prefix](#prefix), those argument names, and
+their values.  The code:
 
 ```C++
 auto v0 = std::vector<int>{1, 2, 3};
@@ -260,10 +253,8 @@ formatting string](#output-formatting) as its first argument.
 To print the data flowing through a range views pipeline (both with [STL
 ranges](https://en.cppreference.com/w/cpp/header/ranges) and
 [Range-v3](https://ericniebler.github.io/range-v3/)), we can use either the `IC_V` or
-`IC_FV` functions, which will lazily print any input coming from the previous view. The
-`IC_VF` function behaves the same as `IC_V`, but accepts the same [format
-string](#output-formatting) as the [*range format string*](#range-format-string) as its
-first argument. Since these functions will be placed within a range views pipeline, the
+`IC_FV` functions, which will lazily print any input coming from the previous view. `IC_FV` behaves the same as `IC_V`, but accepts a [format string](#output-formatting)
+(same syntax as the [*range format string*](#range-format-string)) as its first argument. Since these functions will be placed within a range views pipeline, the
 printing will be done lazily, while each element is generated. For instance:
 
 ```C++
@@ -288,8 +279,8 @@ over it. At each `for` loop iteration one line will be printed, until we have th
 > macro was declared before the "icecream.hpp" header inclusion. This is discussed in
 > details at the [*third-party libraries*](#third-party-libraries) section.
 
-The `IC_V` function has the signature `IC_V(name, projection)`, and the `IC_FV` function
-`IC_FV(fmt, name, projection)`. In both them, the `name` and `projection` parameters as
+`IC_V` has the signature `IC_V(name, projection)`, and `IC_FV` has
+`IC_FV(fmt, name, projection)`. In both, the `name` and `projection` parameters are
 optional.
 
 #### fmt
@@ -339,12 +330,12 @@ when iterated over will print:
 
 ### Return value and Icecream apply macro
 
-The [`IC`](#direct-printing) function (and [`IC_F`](#output-formatting)) won't return any
-value in its general case. Exception to that if called with exactly one argument, when
-then it will return the argument itself.
+[`IC`](#direct-printing) (and [`IC_F`](#output-formatting)) returns no value when called
+with zero or multiple arguments. When called with exactly one argument, it returns that
+argument.
 
-This is done this way so we can use `IC` to inspect a function argument at calling point,
-without further code change. In the code:
+This allows using `IC` to inspect a function argument at the call site without changing
+the code structure. In the code:
 
 ```C++
 my_function(IC(MyClass{}));
@@ -352,7 +343,7 @@ my_function(IC(MyClass{}));
 the `MyClass` object will be forwarded to `my_function` as if the `IC` function wasn't
 there. The `my_function` will continue receiving a rvalue reference to a `MyClass` object.
 
-This approach however is not so practical when the function has multiple arguments. In the code:
+This approach, however, is not practical when the function has multiple arguments. In the code:
 ```C++
 another_function(IC(a), IC(b), IC(c), IC(d));
 ```
@@ -421,7 +412,7 @@ respectively.
 When using the formatting function variants (`IC_F` and `IC_FA`), the same formatting
 string will be applied by default to all of its arguments. That could be a problem if we
 need to have distinct formatting to each argument, or if the arguments have multiple types
-with non mutually valid syntaxes. Therefore, to set a distinct formatting string to a
+with mutually incompatible format syntaxes. Therefore, to set a distinct formatting string to a
 specific argument we can wrap it with the `IC_` function. The code:
 
 ```C++
@@ -457,11 +448,11 @@ auto width = int{7};
 IC(IC_("*<",width,".3", a));
 ```
 
-Will have as result a formatting string `"*<7.3"`, and will print:
+This produces a formatting string `"*<7.3"`, and will print:
 
     ic| a: 1.23***
 
-Just for completeness in the examples, an usage of `IC_FA` and `IC_FV` would be:
+For completeness, here is an example using `IC_FA` and `IC_FV`:
 
 ```C++
 IC_FA("#x", my_function, 10, 20);
@@ -478,138 +469,24 @@ and when iterating on `rv0`:
     ic| bar[2]: 0x2
     ic| bar[4]: 0x4
 
-To `IC_F` and `IC_FA`, the syntax specification of the formatting strings depends both on
-the type `T` being printed, and in that type's [printing strategy](#printing-strategies)
-used by Icecream-cpp.
+For `IC_F` and `IC_FA`, the format string syntax depends on the type being printed and its
+[printing strategy](#printing-strategies).
 
-To `IC_FV`, the formatting syntax if the same as the [Range format
+For `IC_FV`, the format syntax is the same as the [Range format
 string](#range-format-string).
 
 
-### C strings
+## Configuration
 
-C strings are ambiguous. Should a `char* foo` variable be interpreted as a pointer to a
-single `char` or as a null-terminated string? Likewise, is the `char bar[]` variable an
-array of single characters or a null-terminated string? Is `char baz[3]` an array with
-three single characters or is it a string of size two plus a `'\0'`?
+The Icecream-cpp configuration system works *layered by scope*. At the base level we have
+the global `IC_CONFIG` object, shared by the whole program. It is created with all config
+options at their default values, and any change is immediately visible program-wide.
 
-Each one of these interpretations of `foo`, `bar`, and `baz` would be printed in a
-distinct way. To the code:
-
-```C++
-char flavor[] = "pistachio";
-IC(flavor);
-```
-
-all three outputs below are correct, each one having a distinct interpretation of what
-should be the `flavor` variable.
-
-```
-ic| flavor: 0x55587b6f5410
-ic| flavor: ['p', 'i', 's', 't', 'a', 'c', 'h', 'i', 'o', '\u{0}']
-ic| flavor: "pistachio"
-```
-
-A bounded `char` array (i.e.: array with a known size) will either be interpreted as an
-array of single characters or let decay to a `char*`, subject to the
-[`decay_char_array`](#decay_char_array) option.
-
-
-An unbounded `char[]` arrays (i.e.: array with an unknown size) will decay to `char*`
-pointers, and a character pointer will be printed either as a string or as a pointer as
-configured by the [`show_c_string`](#show_c_string) option.
-
-The exact same logic as above applies to C strings of all character types, namely `char`,
-`wchar_t`, `char8_t`, `char16_t`, and `char32_t`.
-
-
-### Character Encoding
-
-Character encoding in C++ is messy.
-
-The `char8_t`, `char16_t`, and `char32_t` strings are well defined. They are capable, and
-do hold Unicode code units of 8, 16, and 32 bits respectively, and they are encoded in
-UTF-8, UTF-16, and UTF-32 also respectively.
-
-The `char` strings have a well defined code unit bit size (given by
-[`CHAR_BIT`](https://en.cppreference.com/w/cpp/types/climits), usually 8 bits), but there
-are no requirements about its encoding.
-
-The `wchar_t` strings have [neither a well defined code unit
-size](https://en.cppreference.com/w/cpp/language/types#Character_types), nor any
-requirements about its encoding.
-
-In a code like this:
-
-```C++
-auto const str = std::string{"foo"};
-std::cout << str;
-```
-
-We will have three character encoding points of interest. In the first one, before
-compiling, that code will be written in a source file in an unspecified *source encoding*.
-In the second interest point, the compiled binary will have the "foo" string stored in an
-also unspecified *execution encoding*. Finally on the third point of interest, the "foo"
-byte stream sent to `std::cout` will be ultimately forwarded to the system, that expects
-that stream being encoded in an also unspecified *output encoding*.
-
-From these three *interest points of character encoding*, both *execution encoding* and
-*output encoding* have impact in the inner working of Icecream-cpp, and there is no way to
-know for sure what is the used encoding in both of them. In face of this uncertainty, the
-adopted strategy is to offer a reasonable default transcoding function, that will try
-convert the data to the right encoding, and allow the user to use its own implementation
-when needed.
-
-Except for wide and Unicode string types (discussed below), when printing any other types
-we will have its serialized textual data in *execution encoding*. That *execution
-encoding* may or may not be the same as the *output encoding*, this one being the encoding
-expected by the configured [output](#output). Because of that, before we send that data to
-the output, we must transcode it to make sure that we have it in *output encoding*. To
-that end, before delivering the text data to the [output](#output), we send it to the
-configured [`output_transcoder`](#output_transcoder) function, that must ensure it is
-encoded in the correct *output encoding*.
-
-When printing the wide and Unicode string types, we need to have one more transcoding
-level, because it is possible that the text data is in a distinct character encoding from
-the expected *execution encoding*. Because of that, additional logic is applied to make
-sure that the strings are in *execution encoding* before we send them to output. That is
-done by applying the [`wide_string_transcoder`](#wide_string_transcoder) and
-[`unicode_transcoder`](#unicode_transcoder) functions respectively.
-
-### Macro disabling
-
-All the Icecream-cpp printing will be disabled in a translation unit if the
-`ICECREAM_DISABLE` macro is defined before the `icecream.hpp` header inclusion.
-
-This can be done either by defining it in the source code:
-
-```C++
-#define ICECREAM_DISABLE
-#include <icecream.hpp>
-```
-
-or as an argument to the compiler. A `-DICECREAM_DISABLE` with
-[GCC](https://gcc.gnu.org/onlinedocs/gcc/Preprocessor-Options.html#index-D-1) and
-[Clang](https://clang.llvm.org/docs/ClangCommandLineReference.html#cmdoption-clang-D-macro),
-and a `/DICECREAM_DISABLE` in
-[MSVC](https://learn.microsoft.com/en-us/cpp/build/reference/d-preprocessor-definitions)
-for example.
-
-This will disable only the printing output, all other functionalities will still work. In
-particular, all the changes to the global [`IC_CONFIG`](#configuration) will be effective.
-
-### Configuration
-
-The Icecream-cpp configuration system works "layered by scope". At the basis level we have
-the global `IC_CONFIG` object. That global instance is shared by the whole running
-program, as would be expected of a global variable. It is created with all config options
-at its default values, and any change is readily seen by the whole program.
-
-At any point in the code we can create a new config layer in the current scope by
-instantiating a new `IC_CONFIG` variable, calling the `IC_CONFIG_SCOPE()` macro function.
-All the config options of this new instance will be at an "unset" state by default, and
-any request to retrieve an option value not yet set will be delegated to its parent. That
-request will go up on the parent chain until the first one having that option set answers.
+At any point, we can create a new config layer in the current scope by calling the
+`IC_CONFIG_SCOPE()` macro, which creates a new `IC_CONFIG` variable. All config options of
+this new instance are *unset* by default, and any request for an unset option is delegated
+to the parent object. The request goes up the parent chain until the first one with that
+option set responds.
 
 All config options are set by using accessor methods of the `IC_CONFIG` object, and they
 can be chained:
@@ -658,11 +535,27 @@ The reading and writing operations on `IC_CONFIG` objects are thread safe.
 
 > [!NOTE]
 > Any modification in an `IC_CONFIG`, other than to the global instance, will be seen only
-> within the current scope. As consequence, those modifications won't propagate to the
+> within the current scope. As a consequence, those modifications won't propagate to the
 > scope of any called function.
 
+**Options:**
+[enable/disable](#enabledisable) |
+[output](#output) |
+[prefix](#prefix) |
+[show_c_string](#show_c_string) |
+[decay_char_array](#decay_char_array) |
+[force_range_strategy](#force_range_strategy) |
+[force_tuple_strategy](#force_tuple_strategy) |
+[force_variant_strategy](#force_variant_strategy) |
+[wide_string_transcoder](#wide_string_transcoder) |
+[unicode_transcoder](#unicode_transcoder) |
+[output_transcoder](#output_transcoder) |
+[line_wrap_width](#line_wrap_width) |
+[include_context](#include_context) |
+[context_delimiter](#context_delimiter)
 
-#### enable/disable
+
+### enable/disable
 
 Enable or disable the output of `IC(...)` macro. The default value is *enabled*.
 
@@ -693,7 +586,7 @@ ic| 1: 1
 ic| 3: 3
 ```
 
-#### output
+### output
 
 Sets where the serialized textual data will be printed. By default that data will be
 printed in the *standard error output*, the same as `std::cerr`.
@@ -715,13 +608,13 @@ auto str = std::string{};
 IC_CONFIG.output(str);
 IC(1, 2);
 ```
-Will print the output `"ic| 1: 1, 2: 2\n"` in the `str` string.
+will print the output `"ic| 1: 1, 2: 2\n"` to the `str` string.
 
 > [!WARNING]
 > Icecream-cpp won't take ownership of the `t` argument, so care must be taken by the user
-> to ensure that it stay alive.
+> to ensure that it stays alive.
 
-#### prefix
+### prefix
 
 A function that generates the text that will be printed before each output.
 
@@ -755,9 +648,9 @@ icecream| 1: 1
 thread 1 | 3: 3
 ```
 
-#### show_c_string
+### show_c_string
 
-Controls if a character pointer variable (`char*` `wchar_t*`, `char8_t*`, `char16_t*`, or
+Controls if a character pointer variable (`char*`, `wchar_t*`, `char8_t*`, `char16_t*`, or
 `char32_t*`) should be interpreted as a null-terminated C string (`true`) or a pointer to
 a `char` (`false`). The default value is `true`.
 
@@ -789,9 +682,9 @@ ic| flavor: "mango";
 ic| flavor: 0x55587b6f5410
 ```
 
-#### decay_char_array
+### decay_char_array
 
-Controls if a character array variable (`char[N]` `wchar_t[N]`, `char8_t[N]`,
+Controls if a character array variable (`char[N]`, `wchar_t[N]`, `char8_t[N]`,
 `char16_t[N]`, or `char32_t[N]`) should decay to a character pointer (when `true`) to be
 printed by the [*strings strategy*](#strings) (subject to the
 [`show_c_string`](#show_c_string) configuration), or remain as an array (when `false`) to
@@ -827,13 +720,12 @@ ic| flavor: "caju";
 ic| flavor: ['c', 'a', 'j', 'u', '\u{0}']
 ```
 
-#### force_range_strategy
+### force_range_strategy
 
 Controls if a range type `T` will be printed using the [range type](#range-types) strategy
 even when the [Formatting](https://en.cppreference.com/w/cpp/utility/format) or
-[{fmt}](https://fmt.dev) libraries would be able to print it. We force the use of *range
-type* strategy here because it supports more useful formatting options that would be
-available otherwise if using some *baseline strategy*.
+[{fmt}](https://fmt.dev) libraries would be able to print it. The *range type* strategy
+supports more useful formatting options than the *baseline strategies*.
 
 This option has a default value of `true`.
 
@@ -846,14 +738,13 @@ This option has a default value of `true`.
     auto force_range_strategy(bool value) -> Config&;
     ```
 
-#### force_tuple_strategy
+### force_tuple_strategy
 
-Controls if a tuple like type `T` will be printed using the [tuple like
+Controls if a tuple-like type `T` will be printed using the [tuple-like
 types](#tuple-like-types) strategy even when the
 [Formatting](https://en.cppreference.com/w/cpp/utility/format) or [{fmt}](https://fmt.dev)
-libraries would be able to print it. We force the use of *tuple like types* strategy here
-because it supports more useful formatting options that would be available otherwise if
-using some *baseline strategy*.
+libraries would be able to print it. The *tuple-like types* strategy supports more useful
+formatting options than the *baseline strategies*.
 
 This option has a default value of `true`.
 
@@ -866,15 +757,14 @@ This option has a default value of `true`.
     auto force_tuple_strategy(bool value) -> Config&;
     ```
 
-#### force_variant_strategy
+### force_variant_strategy
 
 Controls if a variant type `T`
 ([`std::variant`](https://en.cppreference.com/w/cpp/utility/variant) or
 [`boost::variant2::variant`](https://www.boost.org/doc/libs/release/libs/variant2/doc/html/variant2.html))
 will be printed using the [variant types](#variant-types) strategy even when some of the
-*baseline strategies* would be able to print it. We force the use of *variant types*
-strategy here because it supports more useful formatting options that would be available
-otherwise if using some *baseline strategy*.
+*baseline strategies* would be able to print it. The *variant types* strategy supports
+more useful formatting options than the *baseline strategies*.
 
 This option has a default value of `true`.
 
@@ -887,7 +777,7 @@ This option has a default value of `true`.
     auto force_variant_strategy(bool value) -> Config&;
     ```
 
-#### wide_string_transcoder
+### wide_string_transcoder
 
 Function that transcodes a `wchar_t` string, from a system defined encoding to a `char`
 string in the system *execution encoding*.
@@ -903,13 +793,13 @@ actual semantic of a
 [`string_view`](https://en.cppreference.com/w/cpp/string/basic_string_view)), so the user
 must observe the input string size value.
 
-The default implementation will check if the C locale is set to other value than "C" or
-"POSIX". If yes, it will forward the input to the
-[std::wcrtomb](https://en.cppreference.com/w/cpp/string/multibyte/wcrtomb) function.
-Otherwise, it will assume that the input is Unicode encoded (UTF-16 or UTF-32, accordingly
-to the byte size of `wchar_t`), and transcoded it to UTF-8.
+The default implementation checks if the C locale is set to a value other than "C" or
+"POSIX". If so, it forwards the input to
+[std::wcrtomb](https://en.cppreference.com/w/cpp/string/multibyte/wcrtomb). Otherwise, it
+assumes the input is Unicode encoded (UTF-16 or UTF-32, depending on `wchar_t` size) and
+transcodes it to UTF-8.
 
-#### unicode_transcoder
+### unicode_transcoder
 
 Function that transcodes a `char32_t` string, from a UTF-32 encoding to a `char` string in
 the system *execution encoding*.
@@ -925,16 +815,16 @@ actual semantic of a
 [`string_view`](https://en.cppreference.com/w/cpp/string/basic_string_view)), so the user
 must observe the input string size value.
 
-The default implementation will check the C locale is set to other value than "C" or
-"POSIX". If yes, it will forward the input to the
-[std::c32rtomb](https://en.cppreference.com/w/cpp/string/multibyte/c32rtomb) function.
-Otherwise, it will just transcoded it to UTF-8.
+The default implementation checks if the C locale is set to a value other than "C" or
+"POSIX". If so, it forwards the input to
+[std::c32rtomb](https://en.cppreference.com/w/cpp/string/multibyte/c32rtomb). Otherwise,
+it just transcodes to UTF-8.
 
 This function will be used to transcode all the `char8_t`, `char16_t`, and `char32_t`
 strings.  When transcoding `char8_t` and `char16_t` strings, they will be first converted
 to a `char32_t` string, before being sent as input to this function.
 
-#### output_transcoder
+### output_transcoder
 
 Function that transcodes a `char` string, from the system *execution encoding* to a `char`
 string in the system *output encoding*, as expected by the configured [`output`](#output).
@@ -953,9 +843,9 @@ must observe the input string size value.
 The default implementation assumes that the *execution encoding* is the same as the
 *output encoding*, and will return an unchanged input.
 
-#### line_wrap_width
+### line_wrap_width
 
-The maximum number of characters before the output be broken in multiple lines. Default
+The maximum number of characters before the output is broken into multiple lines. Default
 value of `70`.
 
 - get:
@@ -967,7 +857,7 @@ value of `70`.
     auto line_wrap_width(std::size_t value) -> Config&;
     ```
 
-#### include_context
+### include_context
 
 If the context (source name, line number, and function name) should be printed even when
 printing variables. Default value is `false`.
@@ -981,7 +871,7 @@ printing variables. Default value is `false`.
     auto include_context(bool value) -> Config&;
     ```
 
-#### context_delimiter
+### context_delimiter
 
 The string separating the context text from the variables values. Default value is `"- "`.
 
@@ -995,7 +885,7 @@ The string separating the context text from the variables values. Default value 
     ```
 
 
-### Printing strategies
+## Printing Strategies
 
 In order to be printable, a type `T` must satisfy at least one of the strategies described
 in the next sections. If a type `T` is not printable, it can be mended by adding support
@@ -1007,20 +897,34 @@ higher precedence will be chosen. Within the *baseline strategies*, the preceden
 is: *{fmt}*, *Formatting library*, and *IOStreams*. The precedence criteria other than
 these are discussed in each strategy section.
 
+**Strategies:**
+[IOStreams](#iostreams) |
+[Formatting library](#formatting-library) |
+[{fmt}](#fmt-1) |
+[Characters](#characters) |
+[Strings](#strings) |
+[Pointer-like types](#pointer-like-types) |
+[Range types](#range-types) |
+[Tuple-like types](#tuple-like-types) |
+[Optional types](#optional-types) |
+[Variant types](#variant-types) |
+[Exception types](#exception-types) |
+[Clang dump struct](#clang-dump-struct)
 
-#### IOStreams
+
+### IOStreams
 
 Uses the [STL IOStream](https://en.cppreference.com/w/cpp/io) library to print values. A
-type `T` is eligible to this strategy if there exist a function overload
+type `T` is eligible for this strategy if there exists a function overload
 [`operator<<(ostream&,
 <SOME_TYPE>)`](https://en.cppreference.com/w/cpp/io/basic_ostream/operator_ltlt), where a
 value of type `T` is accepted as `<SOME_TYPE>`.
 
-Within the *baseline strategies* the IOStreams has the lowest precedence. So if a type is
+Within the *baseline strategies*, IOStreams has the lowest precedence. So if a type is
 supported either by [{fmt}](#fmt-1) or [Formatting library](#formatting-library) they will
 be used instead.
 
-##### IOStreams format string
+#### IOStreams format string
 
 The format string of IOStreams strategy is strongly based on the ones of [STL
 Formatting](https://en.cppreference.com/w/cpp/utility/format/spec) and
@@ -1040,7 +944,7 @@ integer     ::=  digit+
 digit       ::=  "0"..."9"
 ```
 
-###### [[fill]align]
+##### [[fill]align]
 
 The fill character can be any char. The presence of a fill character is signaled by the
 character following it, which must be one of the alignment options. The meaning of the
@@ -1055,7 +959,7 @@ alignment options is as follows:
 Note that unless a minimum field width is defined, the field width will always be the same
 size as the data to fill it, so that the alignment option has no meaning in this case.
 
-###### [sign]
+##### [sign]
 
 The sign option is only valid for number types, and can be one of the following:
 
@@ -1064,12 +968,12 @@ The sign option is only valid for number types, and can be one of the following:
 | `'+'`  | A sign will be used for both nonnegative as well as negative numbers. |
 | `'-'`  | A sign will be used only for negative numbers. This is the default.   |
 
-###### ["#"]
+##### ["#"]
 
-Causes the “alternate form” to be used for the conversion. The alternate form is defined
+Causes the "alternate form" to be used for the conversion. The alternate form is defined
 differently for different types. This option is only valid for integer and floating-point
 types. For integers, when binary, octal, or hexadecimal output is used, this option adds
-the prefix respective "0b" ("0B"), "0", or "0x" ("0X") to the output value. Whether the
+the respective prefix "0b" ("0B"), "0", or "0x" ("0X") to the output value. Whether the
 prefix is lower-case or upper-case is determined by the case of the type specifier, for
 example, the prefix "0x" is used for the type 'x' and "0X" is used for 'X'. For
 floating-point numbers the alternate form causes the result of the conversion to always
@@ -1077,12 +981,12 @@ contain a decimal-point character, even if no digits follow it. Normally, a deci
 character appears in the result of these conversions only if a digit follows it. In
 addition, for 'g' and 'G' conversions, trailing zeros are not removed from the result.
 
-###### [width]
+##### [width]
 
 A decimal integer defining the minimum field width. If not specified, then the field width
 will be determined by the content.
 
-###### ["." precision]
+##### ["." precision]
 
 The precision is a decimal number indicating how many digits should be displayed after the
 decimal point for a floating-point value formatted with 'f' and 'F', or before and after
@@ -1092,7 +996,7 @@ will be used from the field content. The precision is not allowed for integer, c
 Boolean, and pointer values. Note that a C string must be null-terminated even if
 precision is specified.
 
-###### [type]
+##### [type]
 
 Determines how the data should be presented.
 
@@ -1134,7 +1038,7 @@ The available presentation types for floating-point values are:
 |--------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `'a'`  | Hexadecimal floating point format. Prints the number in base 16 with prefix "0x" and lower-case letters for digits above 9. Uses 'p' to indicate the exponent.                                                                                                              |
 | `'A'`  | Same as 'a' except it uses upper-case letters for the prefix, digits above 9 and to indicate the exponent.                                                                                                                                                                  |
-| `'e'`  | Exponent notation. Prints the number in scientific notation using the letter ‘e’ to indicate the exponent.                                                                                                                                                                  |
+| `'e'`  | Exponent notation. Prints the number in scientific notation using the letter 'e' to indicate the exponent.                                                                                                                                                                  |
 | `'E'`  | Exponent notation. Same as 'e' except it uses an upper-case 'E' as the separator character.                                                                                                                                                                                 |
 | `'f'`  | Fixed point. Displays the number as a fixed-point number.                                                                                                                                                                                                                   |
 | `'F'`  | Fixed point. Same as 'f', but converts nan to NAN and inf to INF.                                                                                                                                                                                                           |
@@ -1142,10 +1046,10 @@ The available presentation types for floating-point values are:
 | `'G'`  | General format. Same as 'g' except switches to 'E' if the number gets too large. The representations of infinity and NaN are uppercased, too.                                                                                                                               |
 
 
-#### Formatting library
+### Formatting library
 
 Uses the [STL formatting](https://en.cppreference.com/w/cpp/utility/format) library to
-print values. A type `T` is eligible to this strategy if there exist a struct
+print values. A type `T` is eligible for this strategy if there exists a struct
 specialization
 [`std::formatter<T>`](https://en.cppreference.com/w/cpp/utility/format/formatter).
 
@@ -1153,45 +1057,45 @@ Within the *baseline strategies* the [{fmt}](#fmt-1) has precedence over [Format
 library](#formatting-library), so if a type is supported by both, the *{fmt}* will be used
 instead.
 
-##### Formatting library format string
+#### Formatting library format string
 
 The format string is forwarded to the *STL Formatting* library. Its syntax can be checked
 [here](https://en.cppreference.com/w/cpp/utility/format/spec).
 
 
-#### {fmt}
+### {fmt}
 
-Uses the [{fmt}](https://fmt.dev) library to print values. A type `T` is eligible to this
-strategy if there exist either a struct specialization
+Uses the [{fmt}](https://fmt.dev) library to print values. A type `T` is eligible for this
+strategy if there exists either a struct specialization
 [`fmt::formatter<T>`](https://fmt.dev/latest/api/#formatting-user-defined-types) or a
 function overload [`auto
 format_as(T)`](https://fmt.dev/latest/api/#formatting-user-defined-types).
 
-{fmt} is a third-party library, so it needs to be available at the system and enabled to
+{fmt} is a third-party library, so it needs to be available on the system and enabled to
 be supported by Icecream-cpp. An explanation of this is in the [*third-party
 libraries*](#third-party-libraries) section.
 
-##### {fmt} format string
+#### {fmt} format string
 
 The format string is forwarded to the *{fmt}* library. Its syntax can be checked
 [here](https://fmt.dev/11.0/syntax/#format-specification-mini-language).
 
 
-#### Characters
+### Characters
 
 All character types: `char`, `wchar_t`, `char8_t`, `char16_t`, and `char32_t`. This
-strategy will [transcode](#character-encoding) any other character type to a `char`, using
+strategy [transcodes](#character-encoding) non-`char` character types to `char`, using
 either [`wide_string_transcoder`](#wide_string_transcoder) or
-[`unicode_transcoder`](#unicode_transcoder) as appropriated, and after that it will
-delegate the actual printing to the [IOStreams](#iostreams) strategy.
+[`unicode_transcoder`](#unicode_transcoder) as appropriate, then delegates the actual
+printing to the [IOStreams](#iostreams) strategy.
 
 This strategy has higher precedence than all the *baseline strategies*.
 
-##### Characters format string
+#### Characters format string
 
 The same as the [IOStreams format string](#iostreams-format-string).
 
-#### Strings
+### Strings
 
 C strings ([with some subtleties](#c-strings)), [STL's
 strings](https://en.cppreference.com/w/cpp/string/basic_string), and [STL's
@@ -1199,18 +1103,18 @@ string_views](https://en.cppreference.com/w/cpp/string/basic_string_view). These
 classes instantiated to all character types: `char`, `wchar_t`, `char8_t`, `char16_t`, and
 `char32_t`.
 
-This strategy will [transcode](#character-encoding) any other character type to a `char`,
+This strategy [transcodes](#character-encoding) non-`char` character types to `char`,
 using either [`wide_string_transcoder`](#wide_string_transcoder) or
-[`unicode_transcoder`](#unicode_transcoder) as appropriated, and after that it will
-delegate the actual printing to the [IOStreams](#iostreams) strategy.
+[`unicode_transcoder`](#unicode_transcoder) as appropriate, then delegates the actual
+printing to the [IOStreams](#iostreams) strategy.
 
-This strategy has higher precedence than all the "baseline strategies".
+This strategy has higher precedence than all the *baseline strategies*.
 
-##### Strings format string
+#### Strings format string
 
 The same as the [IOStreams format string](#iostreams-format-string).
 
-#### Pointer like types
+### Pointer-like types
 
 The `std::unique_ptr<T>` (before C++20) and `boost::scoped_ptr<T>` types will be printed
 like usual raw pointers.
@@ -1234,12 +1138,12 @@ ic| v1: 0x55bcbd840ec0
 ic| v1: expired
 ```
 
-This strategy has a lower precedence than the *baseline strategies*. So if the printing
-type is supported by any one of them it will used instead.
+This strategy has lower precedence than the *baseline strategies*. If the type is
+supported by any of them, that strategy will be used instead.
 
-#### Range types
+### Range types
 
-Concisely, a range is any object of a type `R`, that holds a collection of elements and is
+Concisely, a range is any object of a type `R` that holds a collection of elements and is
 able to provide a [`begin`, `end`) pair, where `begin` is an iterator of type `I` and
 `end` is a sentinel of type `S`. The iterator `I` is used to traverse the elements of `R`,
 and the sentinel `S` is used to signal the end of the range interval, it may or may not be
@@ -1261,14 +1165,14 @@ will print:
 
     ic| v0: [10, 20, 30]
 
-A `view` is close concept to `ranges`. Refer to the [*range views
+A `view` is a closely related concept. Refer to the [*range views
 pipeline*](#range-views-pipeline) section to see how to print them.
 
 This strategy has a higher precedence than the *baseline strategies*, so if the printing
 of a type is supported by both, this strategy will be used instead. This precedence can be
 disabled by the [force_range_strategy](#force_range_strategy) configuration.
 
-##### Range format string
+#### Range format string
 
 The accepted formatting string to a range type is a combination of both a range formatting
 and its elements formatting. The range formatting is syntactically and semantically almost
@@ -1315,10 +1219,9 @@ When printing within a [range views pipeline](#range-views-pipeline) using the `
 function, all the `lower_bound`, `upper_bound`, and `index` values must be positive.
 
 
-#### Tuple like types
+### Tuple-like types
 
-A `std::pair<T1, T2>` or `std::tuple<Ts...>` typed variables will print all of its
-elements.
+`std::pair<T1, T2>` and `std::tuple<Ts...>` variables will print all of their elements.
 
 The code:
 
@@ -1334,17 +1237,17 @@ will print:
 ic| v0: (10, 3.14), v1: (7, 6.28, "bla")
 ```
 
-This strategy has a higher precedence than the *baseline strategies*, so if the printing
-of a type supported by both, this strategy will be used instead. This precedence can be
-disabled by the [`force_tuple_strategy`](#force_tuple_strategy) configuration.
+This strategy has higher precedence than the *baseline strategies*, so if a type is
+supported by both, this strategy will be used instead. This precedence can be disabled by
+the [`force_tuple_strategy`](#force_tuple_strategy) configuration.
 
-##### Tuple like format string
+#### Tuple-like format string
 
-The tuple like formatting specification is based on the syntax suggested in the
+The tuple-like formatting specification is based on the syntax suggested in the
 [Formatting
 Ranges](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p2286r8.html#pair-and-tuple-specifiers)
-paper. Since that part hasn't done to the proposal, with any future change we may revisit
-it here too.
+paper. Since that part hasn't made it into the standard, we may revisit it with any future
+changes.
 
 ```
 tuple_spec  ::= [casing][content]
@@ -1369,26 +1272,26 @@ will print:
 ic| v0: 0x14, "foo", 1.230e-02
 ```
 
-###### casing
+##### casing
 
 Controls the tuple enclosing characters and separator. If not used, the default behavior
 is to enclose the values between `"("` and `")"`, and separated by `", "`.
 
 If `n` is used, the tuple won't be enclosed by parentheses. If `m` is used the tuple will
 be printed "map value like", i.e.: not enclosed by parentheses and using `": "` as
-separator. The `m` specifier is valid just to a *pair* or *2-tuple*.
+separator. The `m` specifier is valid only for a *pair* or *2-tuple*.
 
-###### content
+##### content
 
 The formatting string of each tuple element, separated by a `delimiter` character. This
-can be any character, which value will be defined by the fist read `char` when parsing
+can be any character, whose value will be defined by the first `char` read when parsing
 this rule.
 
 Each `element_fmt` string will be forwarded to the respective tuple element when printing
 it, so it must follow the formatting specification of that particular element type.
 
 
-#### Optional types
+### Optional types
 
 A `std::optional<T>` typed variable will print its value, if it has one, or *nullopt*
 otherwise.
@@ -1407,10 +1310,10 @@ will print:
 ic| v0: 10, v1: nullopt
 ```
 
-This strategy has a lower precedence than the *baseline strategies*. So if the printing
-type is supported by any one of them it will used instead.
+This strategy has lower precedence than the *baseline strategies*. If the type is
+supported by any of them, that strategy will be used instead.
 
-##### Optional types format string
+#### Optional types format string
 
 ```
 optional_spec ::= [":"element_fmt]
@@ -1428,7 +1331,7 @@ will print:
 ic| v0: 0x32
 ```
 
-#### Variant types
+### Variant types
 
 A `std::variant<Ts...>` or `boost::variant2::variant<Ts...>` typed variable will print its
 value.
@@ -1446,11 +1349,11 @@ will print:
 ic| v0: 4.2
 ```
 
-This strategy has a higher precedence than the *baseline strategies*, so if the printing
-of a type supported by both, this strategy will be used instead. This precedence can be
-disabled by the [force_variant_strategy](#force_variant_strategy) configuration.
+This strategy has higher precedence than the *baseline strategies*, so if a type is
+supported by both, this strategy will be used instead. This precedence can be disabled by
+the [force_variant_strategy](#force_variant_strategy) configuration.
 
-##### Variant types format string
+#### Variant types format string
 
 ```
 variant_spec ::= [content]
@@ -1476,11 +1379,11 @@ ic| v0: 110010
 ```
 
 
-#### Exception types
+### Exception types
 
-Types inheriting from `std::exception` will print the return of `std::exception::what()`
-method. If beyond that it inherits from `boost::exception` too, the response of
-`boost::diagnostic_information()` will be also printed.
+Types inheriting from `std::exception` will print the return of `std::exception::what()`.
+If the type also inherits from `boost::exception`, the output of
+`boost::diagnostic_information()` will also be printed.
 
 The code:
 
@@ -1495,12 +1398,12 @@ will print:
 ic| v0: error description
 ```
 
-This strategy has a lower precedence than the *baseline strategies*. So if the printing
-type is supported by any one of them it will used instead.
+This strategy has lower precedence than the *baseline strategies*. If the type is
+supported by any of them, that strategy will be used instead.
 
-#### Clang dump struct
+### Clang dump struct
 
-If using Clang >= 15, a class will be printable even without support to any of the
+With Clang >= 15, a class will be printable even without support from any of the
 *baseline strategies*.
 
 The code:
@@ -1520,36 +1423,36 @@ will print:
 ic| s: {f: 3.14, ii: [1, 2, 3]}
 ```
 
-This strategy has a lowest precedence of all the printing strategies. So if the printing
-type is supported by any one of them it will used instead.
+This strategy has the lowest precedence of all printing strategies. If the type is
+supported by any other strategy, that strategy will be used instead.
 
-### Third-party libraries
 
-The Icecream-cpp doesn't have any required dependency on external libraries besides the
-C++ standard library. However, it optionally supports printing some types of
-[Boost](https://www.boost.org/) and [Range-v3](https://ericniebler.github.io/range-v3/)
-libraries, as well as using the [{fmt}](https://fmt.dev) library alongside the STL's
+## Third-party Libraries
+
+Icecream-cpp has no required dependencies beyond the C++ standard library. However, it
+optionally supports printing some types from
+[Boost](https://www.boost.org/) and [Range-v3](https://ericniebler.github.io/range-v3/),
+as well as using the [{fmt}](https://fmt.dev) library alongside the STL's
 [IOStreams](https://en.cppreference.com/w/cpp/io#Stream-based_I.2FO) and
 [formatting](https://en.cppreference.com/w/cpp/utility/format) libraries.
 
 None of these external libraries are necessary for Icecream-cpp to work properly, and no
-action is required if anyone of them is not available.
+action is required if any of them are not available.
 
-#### Boost
+### Boost
 
-All of the supported Boost types are forward declared in Icecream-cpp header, so you can
-print them with no further work, just like all the STL types.
+All supported Boost types are forward declared in the Icecream-cpp header, so you can
+print them with no further work, just like STL types.
 
 
-#### Range-v3
+### Range-v3
 
-Icecream-cpp can optionally support the printing of Range-v3 views, at any point of a
-pipeline flow. This functionality is fully described at the ["range views
-pipeline"](#range-views-pipeline) section.
+Icecream-cpp can optionally support printing Range-v3 views at any point in a pipeline.
+This functionality is fully described in the [Range views pipeline](#range-views-pipeline)
+section.
 
-The support to printing Range-v3 types can be explicitly enabled by defining the
-`ICECREAM_RANGE_V3` macro before the `icecream.hpp` header inclusion. That will work
-either by explicitly defining it:
+Support for printing Range-v3 types can be explicitly enabled by defining the
+`ICECREAM_RANGE_V3` macro before including `icecream.hpp`:
 
 ```C++
 #define ICECREAM_RANGE_V3
@@ -1562,26 +1465,22 @@ or by using a compiler command line argument if available. In GCC for example:
 gcc -DICECREAM_RANGE_V3 source.cpp
 ```
 
-Even when not explicitly defining the `ICECREAM_RANGE_V3` macro, if the inclusion of the
-`icecream.hpp` header is placed some lines below the inclusion of any Range-v3 header, it
-will be automatically detected and the support enabled. So, a code like this will work
-fine too:
+Even without explicitly defining `ICECREAM_RANGE_V3`, if `icecream.hpp` is included after
+any Range-v3 header, support will be automatically enabled:
 
 ```C++
 #include <range/v3/view/transform.hpp>
 #include "icecream.hpp"
 ```
 
-#### {fmt}
+### {fmt}
 
 Icecream-cpp can optionally use the {fmt} library to get the string representation of a
-type. When available, the {fmt} library will take precedence over the STL's formatting and
-IOStreams libraries. A thorough explanation on this can be seen in the ["baseline
-printable types"](#baseline-printable-types) section.
+type. When available, {fmt} takes precedence over the STL's formatting and IOStreams
+libraries. See the [Printing Strategies](#printing-strategies) section for details.
 
-The support to the {fmt} library can be explicitly enabled by defining the `ICECREAM_FMT`
-macro before the `icecream.hpp` header inclusion. That will work either by explicitly
-defining it:
+Support for the {fmt} library can be explicitly enabled by defining the `ICECREAM_FMT`
+macro before including `icecream.hpp`:
 
 ```C++
 #define ICECREAM_FMT
@@ -1594,21 +1493,147 @@ or by using a compiler command line argument if available. In GCC for example:
 gcc -DICECREAM_FMT source.cpp
 ```
 
-Even when not explicitly defining the `ICECREAM_FMT` macro, if the inclusion of the
-`icecream.hpp` header is placed some lines below the inclusion of any {fmt} header, it
-will be automatically detected and the support enabled. So, a code like this will work
-fine too:
+Even without explicitly defining `ICECREAM_FMT`, if `icecream.hpp` is included after any
+{fmt} header, support will be automatically enabled:
 
 ```C++
 #include <fmt/format.h>
 #include "icecream.hpp"
 ```
 
+
+## Compatibility
+
+Icecream-cpp is tested via CI on the following platforms and compilers:
+
+| Platform | Compilers                                  | C++ Standards       |
+|----------|--------------------------------------------|---------------------|
+| Linux    | GCC 5.4, 9, 14; Clang 8, 19                | 11, 14, 17, 20, 23  |
+| Windows  | MSVC 17.14                                 | 14, 17, 20, 23      |
+| Windows  | MinGW GCC and Clang                        | 11, 14, 17, 20, 23  |
+| macOS    | Apple Clang (Xcode)                        | 11, 14, 17, 20, 23  |
+
+Older compilers (GCC 5.4, GCC 9, Clang 8) are excluded from C++20 and C++23 tests since they
+predate those standards.
+
+
+## Reference
+
+This section covers special topics and edge cases.
+
+### C strings
+
+C strings are ambiguous. Should a `char* foo` variable be interpreted as a pointer to a
+single `char` or as a null-terminated string? Likewise, is the `char bar[]` variable an
+array of single characters or a null-terminated string? Is `char baz[3]` an array with
+three single characters or is it a string of size two plus a `'\0'`?
+
+Each interpretation of `foo`, `bar`, and `baz` would be printed differently. For the
+code:
+
+```C++
+char flavor[] = "pistachio";
+IC(flavor);
+```
+
+all three outputs below are valid, each reflecting a different interpretation of
+`flavor`.
+
+```
+ic| flavor: 0x55587b6f5410
+ic| flavor: ['p', 'i', 's', 't', 'a', 'c', 'h', 'i', 'o', '\u{0}']
+ic| flavor: "pistachio"
+```
+
+A bounded `char` array (i.e., an array with a known size) will either be interpreted as an
+array of single characters or be allowed to decay to a `char*`, depending on the
+[`decay_char_array`](#decay_char_array) option.
+
+
+Unbounded `char[]` arrays (i.e., arrays with an unknown size) will decay to `char*`
+pointers, and a character pointer will be printed either as a string or as a pointer,
+depending on the [`show_c_string`](#show_c_string) option.
+
+The exact same logic as above applies to C strings of all character types, namely `char`,
+`wchar_t`, `char8_t`, `char16_t`, and `char32_t`.
+
+
+### Character Encoding
+
+Character encoding in C++ is messy.
+
+The `char8_t`, `char16_t`, and `char32_t` strings are well defined. They hold Unicode code
+units of 8, 16, and 32 bits respectively, encoded in UTF-8, UTF-16, and UTF-32.
+
+The `char` strings have a well defined code unit bit size (given by
+[`CHAR_BIT`](https://en.cppreference.com/w/cpp/types/climits), usually 8 bits), but there
+are no requirements about their encoding.
+
+The `wchar_t` strings have [neither a well defined code unit
+size](https://en.cppreference.com/w/cpp/language/types#Character_types), nor any
+requirements about their encoding.
+
+In a code like this:
+
+```C++
+auto const str = std::string{"foo"};
+std::cout << str;
+```
+
+There are three character encoding points of interest. First, before compiling, the code
+is written in a source file in an unspecified *source encoding*. Second, the compiled
+binary stores the "foo" string in an unspecified *execution encoding*. Third, the "foo"
+byte stream sent to `std::cout` is forwarded to the system, which expects it to be encoded
+in an unspecified *output encoding*.
+
+Of these three encoding points, both *execution encoding* and *output encoding* affect
+Icecream-cpp's behavior, and there is no way to know for certain what encoding is used.
+In the face of this uncertainty, the adopted strategy is to offer a reasonable default
+transcoding function that tries to convert the data to the right encoding, while allowing
+users to provide their own implementation when needed.
+
+Except for wide and Unicode string types (discussed below), when printing other types
+their serialized textual data is in *execution encoding*. This may or may not match the
+*output encoding* expected by the configured [output](#output). Therefore, before sending
+data to the output, it must be transcoded to ensure it is in *output encoding*. This is
+done by sending the text data to the configured
+[`output_transcoder`](#output_transcoder) function, which must ensure the correct encoding.
+
+When printing the wide and Unicode string types, we need to have one more transcoding
+level, because it is possible that the text data is in a distinct character encoding from
+the expected *execution encoding*. Because of that, additional logic is applied to make
+sure that the strings are in *execution encoding* before we send them to output. That is
+done by applying the [`wide_string_transcoder`](#wide_string_transcoder) and
+[`unicode_transcoder`](#unicode_transcoder) functions respectively.
+
+### Macro disabling
+
+All Icecream-cpp printing will be disabled in a translation unit if the
+`ICECREAM_DISABLE` macro is defined before including `icecream.hpp`.
+
+This can be done either by defining it in the source code:
+
+```C++
+#define ICECREAM_DISABLE
+#include <icecream.hpp>
+```
+
+or as an argument to the compiler. A `-DICECREAM_DISABLE` with
+[GCC](https://gcc.gnu.org/onlinedocs/gcc/Preprocessor-Options.html#index-D-1) and
+[Clang](https://clang.llvm.org/docs/ClangCommandLineReference.html#cmdoption-clang-D-macro),
+and a `/DICECREAM_DISABLE` in
+[MSVC](https://learn.microsoft.com/en-us/cpp/build/reference/d-preprocessor-definitions)
+for example.
+
+This will disable only the printing output, all other functionalities will still work. In
+particular, all the changes to the global [`IC_CONFIG`](#configuration) will be effective.
+
+
 ## Pitfalls
 
-`IC(...)` is a preprocessor macro, it can cause conflicts if there is some
-other `IC` identifier on code. To change the `IC(...)` macro to a longer `ICECREAM(...)`
-one, just define `ICECREAM_LONG_NAME` before the inclusion of `icecream.hpp` header:
+`IC(...)` is a preprocessor macro and can cause conflicts if there is another `IC`
+identifier in the code. To use the longer `ICECREAM(...)` macro instead, define
+`ICECREAM_LONG_NAME` before including `icecream.hpp`:
 
 ```C++
 #define ICECREAM_LONG_NAME

--- a/example_project/README.md
+++ b/example_project/README.md
@@ -1,14 +1,14 @@
-# IceCream-Cpp example project
+# Icecream-cpp example project
 
-This is a "Hello World" project, showing how to integrate Icecream-cpp using CMake, and
-optionally also [Nix](https://nixos.org) or [Conan](https://conan.io).
+This is a "Hello World" project showing how to integrate Icecream-cpp using CMake, and
+optionally [Nix](https://nixos.org) or [Conan](https://conan.io).
 
-Note that in this examples Icecream-cpp will be installed in the system. If you chose copy
-the header file to your project instead, all that you will need is `#include` it in your
+Note that in these examples Icecream-cpp will be installed in the system. If you choose to
+copy the header file to your project instead, all you need to do is `#include` it in your
 source and compile the project as usual.
 
-All the next instructions assumes that you are in an shell opened inside the
-"example_project" directory.
+All instructions below assume you are in a shell opened inside the "example_project"
+directory.
 
 ## Building it with Conan
 
@@ -24,10 +24,10 @@ cmake .. -DCMAKE_TOOLCHAIN_FILE=conan_toolchain.cmake -DCMAKE_BUILD_TYPE=Debug
 cmake --build .
 ```
 
-## Building on CMake only
+## Building with CMake only
 
-Before entering the next instructions, a working system wide Icecream-cpp installation is
-presumed. To get that, either install it by a distribution package, or follow the
+Before following these instructions, a working system-wide Icecream-cpp installation is
+required. To do so, either install it from a distribution package or follow the
 instructions [here](https://github.com/renatoGarcia/icecream-cpp/tree/master#install).
 
 


### PR DESCRIPTION
- Restructure sections for better flow
- Simplify table of contents
- Add local navigation links within Configuration and Printing Strategies sections
- Add Compatibility section documenting CI-tested platforms and compilers
- Fix grammar and awkward phrasing throughout both READMEs
- Update intro examples for clarity